### PR TITLE
Add htonll define

### DIFF
--- a/Dispatcher.cpp
+++ b/Dispatcher.cpp
@@ -18,6 +18,8 @@
 
 #include "precomp.hpp"
 
+#define htonll(x) ((((uint64_t)htonl(x)) << 32) + htonl((x) >> 32))
+
 static std::string::size_type fromHex(char c) {
 	if (c >= 'A' && c <= 'F') {
 		c -= 'A' - 'a';


### PR DESCRIPTION
Code wouldn't compile for me otherwise. I have tried both WSL2 Ubuntu and NVIDIA's OpenCL docker images, the two failed compile with "error: ‘htonll’ was not declared in this scope; did you mean ‘htonl’?".