### PR TITLE
Fix link to article regarding vulnerability in the original tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Profanity is a high performance (probably the fastest!) vanity address generator
 
 # Important to know
 
-A previous version of this project has a known critical issue due to a bad source of randomness. The issue enables attackers to recover private key from public key: https://blog.1inch.io/a-vulnerability-disclosed-in-profanity-an-ethereum-vanity-address-tool-68ed7455fc8c
+A previous version of this project has a known critical issue due to a bad source of randomness. The issue enables attackers to recover private key from public key: https://blog.1inch.io/a-vulnerability-disclosed-in-profanity-an-ethereum-vanity-address-tool
 
 This project "profanity2" was forked from the original project and modified to guarantee **safety by design**. This means source code of this project do not require any audits, but still guarantee safe usage.
 


### PR DESCRIPTION
The link seems to be broken and results in a 404 page. I've replaced it with a link to the active article.