### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.so
 cache-opencl.*
 bin
+profanity2.x64


### PR DESCRIPTION
I've noticed that the `profanity2.x64` file, which is generated after building the project, wasn't included in the `.gitignore`. This file is specific to each person's environment and shouldn't be tracked by Git as it can lead to unnecessary conflicts. I have added it to the `.gitignore` to prevent this file from being accidentally committed to the repository. Thank you.