### PR TITLE
Add mode zeroBytes

### DIFF
--- a/Mode.cpp
+++ b/Mode.cpp
@@ -84,6 +84,13 @@ Mode Mode::range(const cl_uchar min, const cl_uchar max) {
 	return r;
 }
 
+Mode Mode::zeroBytes() {
+	Mode r;
+	r.name = "zeroBytes";
+	r.kernel = "profanity_score_zerobytes";
+	return r;
+}
+
 Mode Mode::letters() {
 	Mode r = range(10, 15);
 	r.name = "letters";

--- a/Mode.hpp
+++ b/Mode.hpp
@@ -28,6 +28,7 @@ class Mode {
 
 		static Mode benchmark();
 		static Mode zeros();
+		static Mode zeroBytes();
 		static Mode letters();
 		static Mode numbers();
 		static Mode doubles();

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ usage: ./profanity2 [OPTIONS]
     --numbers               Score on numbers anywhere in hash.
     --mirror                Score on mirroring from center.
     --leading-doubles       Score on hashes leading with hexadecimal pairs
+    --zero-bytes            Score on hashes containing the most zero bytes
 
   Modes with arguments:
     --leading <single hex>  Score on hashes leading with given hex character.
@@ -93,6 +94,7 @@ usage: ./profanity2 [OPTIONS]
     ./profanity2 --leading-range -m 10 -M 12 -z HEX_PUBLIC_KEY_128_CHARS_LONG
     ./profanity2 --range -m 0 -M 1 -z HEX_PUBLIC_KEY_128_CHARS_LONG
     ./profanity2 --contract --leading 0 -z HEX_PUBLIC_KEY_128_CHARS_LONG
+    ./profanity2 --contract --zero-bytes -z HEX_PUBLIC_KEY_128_CHARS_LONG
 
   About:
     profanity2 is a vanity address generator for Ethereum that utilizes

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ usage: ./profanity2 [OPTIONS]
     --numbers               Score on numbers anywhere in hash.
     --mirror                Score on mirroring from center.
     --leading-doubles       Score on hashes leading with hexadecimal pairs
-    --zero-bytes            Score on hashes containing the most zero bytes
+    -b, --zero-bytes            Score on hashes containing the most zero bytes
 
   Modes with arguments:
     --leading <single hex>  Score on hashes leading with given hex character.

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ usage: ./profanity2 [OPTIONS]
     --numbers               Score on numbers anywhere in hash.
     --mirror                Score on mirroring from center.
     --leading-doubles       Score on hashes leading with hexadecimal pairs
-    -b, --zero-bytes            Score on hashes containing the most zero bytes
+    -b, --zero-bytes        Score on hashes containing the most zero bytes
 
   Modes with arguments:
     --leading <single hex>  Score on hashes leading with given hex character.

--- a/help.hpp
+++ b/help.hpp
@@ -17,7 +17,7 @@ usage: ./profanity2 [OPTIONS]
     --numbers               Score on numbers anywhere in hash.
     --mirror                Score on mirroring from center.
     --leading-doubles       Score on hashes leading with hexadecimal pairs
-    --zero-bytes            Score on hashes containing the most zero bytes
+    -b, --zero-bytes            Score on hashes containing the most zero bytes
 
   Modes with arguments:
     --leading <single hex>  Score on hashes leading with given hex character.

--- a/help.hpp
+++ b/help.hpp
@@ -17,7 +17,7 @@ usage: ./profanity2 [OPTIONS]
     --numbers               Score on numbers anywhere in hash.
     --mirror                Score on mirroring from center.
     --leading-doubles       Score on hashes leading with hexadecimal pairs
-    -b, --zero-bytes            Score on hashes containing the most zero bytes
+    -b, --zero-bytes        Score on hashes containing the most zero bytes
 
   Modes with arguments:
     --leading <single hex>  Score on hashes leading with given hex character.

--- a/help.hpp
+++ b/help.hpp
@@ -17,6 +17,7 @@ usage: ./profanity2 [OPTIONS]
     --numbers               Score on numbers anywhere in hash.
     --mirror                Score on mirroring from center.
     --leading-doubles       Score on hashes leading with hexadecimal pairs
+    --zero-bytes            Score on hashes containing the most zero bytes
 
   Modes with arguments:
     --leading <single hex>  Score on hashes leading with given hex character.

--- a/profanity.cl
+++ b/profanity.cl
@@ -791,7 +791,7 @@ __kernel void profanity_score_zerobytes(__global mp_number * const pInverse, __g
 
 	for (int i = 0; i < 20; ++i) {
 		if (hash[i] == 0) {
-      score++;
+			score++;
 		}
 	}
 

--- a/profanity.cl
+++ b/profanity.cl
@@ -784,6 +784,20 @@ __kernel void profanity_score_range(__global mp_number * const pInverse, __globa
 	profanity_result_update(id, hash, pResult, score, scoreMax);
 }
 
+__kernel void profanity_score_zerobytes(__global mp_number * const pInverse, __global result * const pResult, __constant const uchar * const data1, __constant const uchar * const data2, const uchar scoreMax) {
+	const size_t id = get_global_id(0);
+	__global const uchar * const hash = pInverse[id].d;
+	int score = 0;
+
+	for (int i = 0; i < 20; ++i) {
+		if (hash[i] == 0) {
+      score++;
+		}
+	}
+
+	profanity_result_update(id, hash, pResult, score, scoreMax);
+}
+
 __kernel void profanity_score_leadingrange(__global mp_number * const pInverse, __global result * const pResult, __constant const uchar * const data1, __constant const uchar * const data2, const uchar scoreMax) {
 	const size_t id = get_global_id(0);
 	__global const uchar * const hash = pInverse[id].d;

--- a/profanity.cpp
+++ b/profanity.cpp
@@ -192,7 +192,7 @@ int main(int argc, char * * argv) {
 		argp.addSwitch('I', "inverse-multiple", inverseMultiple);
 		argp.addSwitch('c', "contract", bMineContract);
 		argp.addSwitch('z', "publicKey", strPublicKey);
-		argp.addSwitch('Z', "zero-bytes", bModeZeroBytes);
+		argp.addSwitch('b', "zero-bytes", bModeZeroBytes);
 
 		if (!argp.parse()) {
 			std::cout << "error: bad arguments, try again :<" << std::endl;

--- a/profanity.cpp
+++ b/profanity.cpp
@@ -151,6 +151,7 @@ int main(int argc, char * * argv) {
 		bool bHelp = false;
 		bool bModeBenchmark = false;
 		bool bModeZeros = false;
+		bool bModeZeroBytes = false;
 		bool bModeLetters = false;
 		bool bModeNumbers = false;
 		std::string strModeLeading;
@@ -191,6 +192,7 @@ int main(int argc, char * * argv) {
 		argp.addSwitch('I', "inverse-multiple", inverseMultiple);
 		argp.addSwitch('c', "contract", bMineContract);
 		argp.addSwitch('z', "publicKey", strPublicKey);
+		argp.addSwitch('Z', "zero-bytes", bModeZeroBytes);
 
 		if (!argp.parse()) {
 			std::cout << "error: bad arguments, try again :<" << std::endl;
@@ -223,6 +225,8 @@ int main(int argc, char * * argv) {
 			mode = Mode::mirror();
 		} else if (bModeDoubles) {
 			mode = Mode::doubles();
+		} else if (bModeZeroBytes) {
+			mode = Mode::zeroBytes();
 		} else {
 			std::cout << g_strHelp << std::endl;
 			return 0;


### PR DESCRIPTION
Adding a mode that scores the results based on the number of zero-bytes. This is similar to the mode "zeros" but for people who want a vanity address with zeros for cheaper calldata gas, this mode should be chosen over "zeros".\

More details #35 