### PR TITLE
Exact match mode with multiple keys output

### DIFF
--- a/Dispatcher.cpp
+++ b/Dispatcher.cpp
@@ -140,8 +140,9 @@ cl_command_queue Dispatcher::Device::createQueue(cl_context & clContext, cl_devi
 }
 
 cl_kernel Dispatcher::Device::createKernel(cl_program & clProgram, const std::string s) {
-	cl_kernel ret  = clCreateKernel(clProgram, s.c_str(), NULL);
-	return ret == NULL ? throw std::runtime_error("failed to create kernel \"" + s + "\"") : ret;
+	cl_int errorCode;
+	cl_kernel ret  = clCreateKernel(clProgram, s.c_str(), &errorCode);
+	return ret == NULL ? throw std::runtime_error("failed to create kernel \"" + s + "\"" + ", code: " + toString(errorCode)) : ret;
 }
 
 cl_ulong4 Dispatcher::Device::createSeed() {

--- a/Dispatcher.hpp
+++ b/Dispatcher.hpp
@@ -77,6 +77,8 @@ class Dispatcher {
 			// Initialization
 			size_t m_sizeInitialized;
 			cl_event m_eventFinished;
+
+			size_t m_lastCursorIndex;
 		};
 
 	public:
@@ -96,6 +98,7 @@ class Dispatcher {
 		void enqueueKernelDevice(Device & d, cl_kernel & clKernel, size_t worksizeGlobal, cl_event * pEvent);
 
 		void handleResult(Device & d);
+		void handleExactResult(Device & d);
 		void randomizeSeed(Device & d);
 
 		void onEvent(cl_event event, cl_int status, Device & d);

--- a/Mode.cpp
+++ b/Mode.cpp
@@ -37,6 +37,20 @@ static std::string::size_type hexValue(char c) {
 	return ret;
 }
 
+//
+// Pattern:
+//					1337________________________________C0DE
+//          10000______________________________00001
+//
+// | #   | Chr | iHi  | iLo  |  mHi |  mLo | d1[i] | d2[i] |
+// |-----------|------|------|------|------|-------|-------|
+// | 0   | d d | 13   | 13   | 0xF0 | 0x0F | 0xFF  | 0xDD  |
+// | 1   | 0 b | 0    | 11   | 0xF0 | 0x0F | 0xFF  | 0x0B  |
+// | 2   | b _ | 11   | npos | 0xF0 | 0x00 | 0xF0  | 0x00  |
+// | 3-9 | _ _ | npos | npos | 0x00 | 0x00 | 0x00  | 0x00  |
+// | 10  | d d | 13   | 13   | 0xF0 | 0x0F | 0xFF  | 0xDD  |
+// | 11  | 0 b | 0    | 11   | 0xF0 | 0x0F | 0xFF  | 0x0B  |
+
 Mode Mode::matching(const std::string strHex) {
 	Mode r;
 	r.name = "matching";
@@ -46,7 +60,7 @@ Mode Mode::matching(const std::string strHex) {
 	std::fill( r.data2, r.data2 + sizeof(r.data2), cl_uchar(0) );
 
 	auto index = 0;
-	
+
 	for( size_t i = 0; i < strHex.size(); i += 2 ) {
 		const auto indexHi = hexValueNoException(strHex[i]);
 		const auto indexLo = i + 1 < strHex.size() ? hexValueNoException(strHex[i+1]) : std::string::npos;
@@ -65,6 +79,16 @@ Mode Mode::matching(const std::string strHex) {
 
 	return r;
 }
+
+Mode Mode::exact(const std::string strHex) {
+	Mode r = matching(strHex);
+
+	r.name = "exact";
+	r.kernel = "profanity_exact_match";
+
+	return r;
+}
+
 
 Mode Mode::leading(const char charLeading) {
 

--- a/Mode.hpp
+++ b/Mode.hpp
@@ -21,6 +21,7 @@ class Mode {
 
 	public:
 		static Mode matching(const std::string strHex);
+		static Mode exact(const std::string strHex);
 		static Mode range(const cl_uchar min, const cl_uchar max);
 		static Mode leading(const char charLeading);
 		static Mode leadingRange(const cl_uchar min, const cl_uchar max);

--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ usage: ./profanity2 [OPTIONS]
 
   Modes with arguments:
     --leading <single hex>  Score on hashes leading with given hex character.
-    --matching <hex string> Score on hashes matching given hex string.
+    --matching <hex mask>   Score on hashes matching given hex string.
+    -e, --exact <hex mask>  Score on all hashes exactly matching given mask.
 
   Advanced modes:
     --contract              Instead of account address, score the contract
@@ -88,8 +89,9 @@ usage: ./profanity2 [OPTIONS]
 
   Examples:
     ./profanity2 --leading f -z HEX_PUBLIC_KEY_128_CHARS_LONG
-    ./profanity2 --matching dead -z HEX_PUBLIC_KEY_128_CHARS_LONG
-    ./profanity2 --matching badXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXbad -z HEX_PUBLIC_KEY_128_CHARS_LONG
+    ./profanity2 --matching beef -z HEX_PUBLIC_KEY_128_CHARS_LONG
+    ./profanity2 --matching 1337________________________________C0DE -z HEX_PUBLIC_KEY_128_CHARS_LONG
+    ./profanity2 --exact 1337________________________________C0DE -z HEX_PUBLIC_KEY_128_CHARS_LONG
     ./profanity2 --leading-range -m 0 -M 1 -z HEX_PUBLIC_KEY_128_CHARS_LONG
     ./profanity2 --leading-range -m 10 -M 12 -z HEX_PUBLIC_KEY_128_CHARS_LONG
     ./profanity2 --range -m 0 -M 1 -z HEX_PUBLIC_KEY_128_CHARS_LONG
@@ -127,4 +129,3 @@ usage: ./profanity2 [OPTIONS]
 |Apple Silicon M1<br/>(8-core GPU)|-|-|-|45.0 MH/s| ~97s
 |Apple Silicon M1 Max<br/>(32-core GPU)|-|-|-|172.0 MH/s| ~25s
 |Apple Silicon M3 Pro<br/>(18-core GPU)|-|-|-|97 MH/s| ~45s
-

--- a/help.hpp
+++ b/help.hpp
@@ -21,7 +21,8 @@ usage: ./profanity2 [OPTIONS]
 
   Modes with arguments:
     --leading <single hex>  Score on hashes leading with given hex character.
-    --matching <hex string> Score on hashes matching given hex string.
+    --matching <hex mask>   Score on hashes matching given hex string.
+    -e, --exact <hex mask>  Score on all hashes exactly matching given mask.
 
   Advanced modes:
     --contract              Instead of account address, score the contract
@@ -49,12 +50,14 @@ usage: ./profanity2 [OPTIONS]
 
   Examples:
     ./profanity2 --leading f -z HEX_PUBLIC_KEY_128_CHARS_LONG
-    ./profanity2 --matching dead -z HEX_PUBLIC_KEY_128_CHARS_LONG
-    ./profanity2 --matching badXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXbad -z HEX_PUBLIC_KEY_128_CHARS_LONG
+    ./profanity2 --matching beef -z HEX_PUBLIC_KEY_128_CHARS_LONG
+    ./profanity2 --matching 1337________________________________C0DE -z HEX_PUBLIC_KEY_128_CHARS_LONG
+    ./profanity2 --exact 1337________________________________C0DE -z HEX_PUBLIC_KEY_128_CHARS_LONG
     ./profanity2 --leading-range -m 0 -M 1 -z HEX_PUBLIC_KEY_128_CHARS_LONG
     ./profanity2 --leading-range -m 10 -M 12 -z HEX_PUBLIC_KEY_128_CHARS_LONG
     ./profanity2 --range -m 0 -M 1 -z HEX_PUBLIC_KEY_128_CHARS_LONG
     ./profanity2 --contract --leading 0 -z HEX_PUBLIC_KEY_128_CHARS_LONG
+    ./profanity2 --contract --zero-bytes -z HEX_PUBLIC_KEY_128_CHARS_LONG
 
   About:
     profanity2 is a vanity address generator for Ethereum that utilizes

--- a/profanity.cl
+++ b/profanity.cl
@@ -5,7 +5,7 @@
  *
  * Terminology
  * ===========
- * 
+ *
  *
  * Cutting corners
  * ===============
@@ -16,7 +16,7 @@
  * doing it right is too severe. In the future I'll introduce a periodic check
  * after N amount of cycles that verifies the integrity of all the points to
  * make sure that even very unlikely event are at some point rectified.
- * 
+ *
  * Currently, if any of the points in the kernels experiences the unlikely event
  * of an error then that point is forever garbage and your runtime-performance
  * will in practice be (i*I-N) / (i*I). i and I here refers to the values given
@@ -331,7 +331,7 @@ void mp_mod_mul(mp_number * const r, const mp_number * const X, const mp_number 
 	*r = Z;
 }
 
-// Modular inversion of a number. 
+// Modular inversion of a number.
 void mp_mod_inverse(mp_number * const r) {
 	mp_number A = { { 1 } };
 	mp_number C = { { 0 } };
@@ -474,7 +474,7 @@ __kernel void profanity_init(__global const point * const precomp, __global mp_n
 	mp_mod_sub_gx(&tmp1, &p.x);
 	mp_mod_inverse(&tmp1);
 
-	mp_mod_sub_gy(&tmp2, &p.y); 
+	mp_mod_sub_gy(&tmp2, &p.y);
 	mp_mod_mul(&tmp1, &tmp1, &tmp2);
 
 	// Jump to next point (precomp[0] is the generator point G)
@@ -494,7 +494,7 @@ __kernel void profanity_init(__global const point * const precomp, __global mp_n
 
 // This kernel calculates several modular inversions at once with just one inverse.
 // It's an implementation of Algorithm 2.11 from Modern Computer Arithmetic:
-// https://members.loria.fr/PZimmermann/mca/pub226.html 
+// https://members.loria.fr/PZimmermann/mca/pub226.html
 //
 // My RX 480 is very sensitive to changes in the second loop and sometimes I have
 // to make seemingly non-functional changes to the code to make the compiler
@@ -563,7 +563,7 @@ __kernel void profanity_inverse(__global const mp_number * const pDeltaX, __glob
 // Then we have:
 //   d = x - G_x <=> x = d + G_x
 //   x' = λ² - G_x - x <=> x_r = λ² - G_x - d - G_x = λ² - 2G_x - d
-//   
+//
 //   d' = x' - G_x = λ² - 2G_x - d - G_x = λ² - 3G_x - d
 //
 // So we see that the new delta d' can be calculated with the same
@@ -585,9 +585,9 @@ __kernel void profanity_inverse(__global const mp_number * const pDeltaX, __glob
 // But we aren't done yet! Let's expand the expression for the next
 // lambda, λ'. We have:
 //   λ' = (y' - G_y) / d'
-//      = (-λ * d' - G_y - G_y) / d' 
-//      = (-λ * d' - 2*G_y) / d' 
-//      = -λ - 2*G_y / d' 
+//      = (-λ * d' - G_y - G_y) / d'
+//      = (-λ * d' - 2*G_y) / d'
+//      = -λ - 2*G_y / d'
 //
 // So the next lambda value can be calculated from the old one. This in
 // and of itself is not so interesting but the fact that the term -2 * G_y
@@ -602,7 +602,7 @@ __kernel void profanity_inverse(__global const mp_number * const pDeltaX, __glob
 // but it's still a net gain. To additionally decrease memory access
 // overhead I never any longer store the Y coordinate. Instead I
 // calculate it at the end directly from the lambda and deltaX.
-// 
+//
 // In addition to this some algebraic re-ordering has been done to move
 // constants into the same argument to a new function mp_mod_sub_const
 // in hopes that using constant storage instead of private storage
@@ -693,7 +693,7 @@ void profanity_result_update(const size_t id, __global const uchar * const hash,
 
 __kernel void profanity_transform_contract(__global mp_number * const pInverse) {
 	const size_t id = get_global_id(0);
-	__global const uchar * const hash = pInverse[id].d;
+	__global const uchar * const hash = (__global const uchar * const)pInverse[id].d;
 
 	ethhash h;
 	for (int i = 0; i < 50; ++i) {
@@ -719,7 +719,7 @@ __kernel void profanity_transform_contract(__global mp_number * const pInverse) 
 
 __kernel void profanity_score_benchmark(__global mp_number * const pInverse, __global result * const pResult, __constant const uchar * const data1, __constant const uchar * const data2, const uchar scoreMax) {
 	const size_t id = get_global_id(0);
-	__global const uchar * const hash = pInverse[id].d;
+	__global const uchar * const hash = (__global const uchar * const)pInverse[id].d;
 	int score = 0;
 
 	profanity_result_update(id, hash, pResult, score, scoreMax);
@@ -727,7 +727,7 @@ __kernel void profanity_score_benchmark(__global mp_number * const pInverse, __g
 
 __kernel void profanity_score_matching(__global mp_number * const pInverse, __global result * const pResult, __constant const uchar * const data1, __constant const uchar * const data2, const uchar scoreMax) {
 	const size_t id = get_global_id(0);
-	__global const uchar * const hash = pInverse[id].d;
+	__global const uchar * const hash = (__global const uchar * const)pInverse[id].d;
 	int score = 0;
 
 	for (int i = 0; i < 20; ++i) {
@@ -741,7 +741,7 @@ __kernel void profanity_score_matching(__global mp_number * const pInverse, __gl
 
 __kernel void profanity_score_leading(__global mp_number * const pInverse, __global result * const pResult, __constant const uchar * const data1, __constant const uchar * const data2, const uchar scoreMax) {
 	const size_t id = get_global_id(0);
-	__global const uchar * const hash = pInverse[id].d;
+	__global const uchar * const hash = (__global const uchar * const)pInverse[id].d;
 	int score = 0;
 
 	for (int i = 0; i < 20; ++i) {
@@ -765,7 +765,7 @@ __kernel void profanity_score_leading(__global mp_number * const pInverse, __glo
 
 __kernel void profanity_score_range(__global mp_number * const pInverse, __global result * const pResult, __constant const uchar * const data1, __constant const uchar * const data2, const uchar scoreMax) {
 	const size_t id = get_global_id(0);
-	__global const uchar * const hash = pInverse[id].d;
+	__global const uchar * const hash = (__global const uchar * const)pInverse[id].d;
 	int score = 0;
 
 	for (int i = 0; i < 20; ++i) {
@@ -786,7 +786,7 @@ __kernel void profanity_score_range(__global mp_number * const pInverse, __globa
 
 __kernel void profanity_score_zerobytes(__global mp_number * const pInverse, __global result * const pResult, __constant const uchar * const data1, __constant const uchar * const data2, const uchar scoreMax) {
 	const size_t id = get_global_id(0);
-	__global const uchar * const hash = pInverse[id].d;
+	__global const uchar * const hash = (__global const uchar * const)pInverse[id].d;
 	int score = 0;
 
 	for (int i = 0; i < 20; ++i) {
@@ -800,7 +800,7 @@ __kernel void profanity_score_zerobytes(__global mp_number * const pInverse, __g
 
 __kernel void profanity_score_leadingrange(__global mp_number * const pInverse, __global result * const pResult, __constant const uchar * const data1, __constant const uchar * const data2, const uchar scoreMax) {
 	const size_t id = get_global_id(0);
-	__global const uchar * const hash = pInverse[id].d;
+	__global const uchar * const hash = (__global const uchar * const)pInverse[id].d;
 	int score = 0;
 
 	for (int i = 0; i < 20; ++i) {
@@ -827,7 +827,7 @@ __kernel void profanity_score_leadingrange(__global mp_number * const pInverse, 
 
 __kernel void profanity_score_mirror(__global mp_number * const pInverse, __global result * const pResult, __constant const uchar * const data1, __constant const uchar * const data2, const uchar scoreMax) {
 	const size_t id = get_global_id(0);
-	__global const uchar * const hash = pInverse[id].d;
+	__global const uchar * const hash = (__global const uchar * const)pInverse[id].d;
 	int score = 0;
 
 	for (int i = 0; i < 10; ++i) {
@@ -855,7 +855,7 @@ __kernel void profanity_score_mirror(__global mp_number * const pInverse, __glob
 
 __kernel void profanity_score_doubles(__global mp_number * const pInverse, __global result * const pResult, __constant const uchar * const data1, __constant const uchar * const data2, const uchar scoreMax) {
 	const size_t id = get_global_id(0);
-	__global const uchar * const hash = pInverse[id].d;
+	__global const uchar * const hash = (__global const uchar * const)pInverse[id].d;
 	int score = 0;
 
 	for (int i = 0; i < 20; ++i) {

--- a/profanity.cpp
+++ b/profanity.cpp
@@ -334,19 +334,22 @@ int main(int argc, char * * argv) {
 		// Build the program
 		std::cout << "  Building program..." << std::flush;
 		const std::string strBuildOptions = "-D PROFANITY_INVERSE_SIZE=" + toString(inverseSize) + " -D PROFANITY_MAX_SCORE=" + toString(PROFANITY_MAX_SCORE);
-		if (printResult(clBuildProgram(clProgram, vDevices.size(), vDevices.data(), strBuildOptions.c_str(), NULL, NULL))) {
+		auto res = printResult(clBuildProgram(clProgram, vDevices.size(), vDevices.data(), strBuildOptions.c_str(), NULL, NULL));
+
 #ifdef PROFANITY_DEBUG
-			std::cout << std::endl;
-			std::cout << "build log:" << std::endl;
+		std::cout << std::endl;
+		std::cout << "build log:" << std::endl;
 
-			size_t sizeLog;
-			clGetProgramBuildInfo(clProgram, vDevices[0], CL_PROGRAM_BUILD_LOG, 0, NULL, &sizeLog);
-			char * const szLog = new char[sizeLog];
-			clGetProgramBuildInfo(clProgram, vDevices[0], CL_PROGRAM_BUILD_LOG, sizeLog, szLog, NULL);
+		size_t sizeLog;
+		clGetProgramBuildInfo(clProgram, vDevices[0], CL_PROGRAM_BUILD_LOG, 0, NULL, &sizeLog);
+		char * const szLog = new char[sizeLog];
+		clGetProgramBuildInfo(clProgram, vDevices[0], CL_PROGRAM_BUILD_LOG, sizeLog, szLog, NULL);
 
-			std::cout << szLog << std::endl;
-			delete[] szLog;
+		std::cout << szLog << std::endl;
+		delete[] szLog;
 #endif
+
+		if (res) {
 			return 1;
 		}
 

--- a/profanity.cpp
+++ b/profanity.cpp
@@ -156,6 +156,7 @@ int main(int argc, char * * argv) {
 		bool bModeNumbers = false;
 		std::string strModeLeading;
 		std::string strModeMatching;
+		std::string strModeExact;
 		std::string strPublicKey;
 		bool bModeLeadingRange = false;
 		bool bModeRange = false;
@@ -193,6 +194,7 @@ int main(int argc, char * * argv) {
 		argp.addSwitch('c', "contract", bMineContract);
 		argp.addSwitch('z', "publicKey", strPublicKey);
 		argp.addSwitch('b', "zero-bytes", bModeZeroBytes);
+		argp.addSwitch('e', "exact", strModeExact);
 
 		if (!argp.parse()) {
 			std::cout << "error: bad arguments, try again :<" << std::endl;
@@ -217,6 +219,8 @@ int main(int argc, char * * argv) {
 			mode = Mode::leading(strModeLeading.front());
 		} else if (!strModeMatching.empty()) {
 			mode = Mode::matching(strModeMatching);
+		} else if (!strModeExact.empty()) {
+			mode = Mode::exact(strModeExact);
 		} else if (bModeLeadingRange) {
 			mode = Mode::leadingRange(rangeMin, rangeMax);
 		} else if (bModeRange) {
@@ -231,7 +235,7 @@ int main(int argc, char * * argv) {
 			std::cout << g_strHelp << std::endl;
 			return 0;
 		}
-		
+
 		if (strPublicKey.length() == 0) {
 			std::cout << "error: this tool requires your public key to derive it's private key security" << std::endl;
 			return 1;
@@ -242,6 +246,8 @@ int main(int argc, char * * argv) {
 			return 1;
 		}
 
+		std::cout << "Public key: " << strPublicKey << std::endl;
+
 		std::cout << "Mode: " << mode.name << std::endl;
 
 		if (bMineContract) {
@@ -249,7 +255,9 @@ int main(int argc, char * * argv) {
 		} else {
 			mode.target = ADDRESS;
 		}
-		std::cout << "Target: " << mode.transformName() << std:: endl;
+
+		std::cout << "Target: " << mode.transformName() << std::endl;
+		std::cout << std::endl;
 
 		std::vector<cl_device_id> vFoundDevices = getAllDevices();
 		std::vector<cl_device_id> vDevices;
@@ -382,4 +390,3 @@ int main(int argc, char * * argv) {
 
 	return 1;
 }
-


### PR DESCRIPTION
This PR adds new `--exact` mode, that prints all _exact_ matches for given mask.

Example output 

```
./profanity2.x64 -z $HEX_PUBLIC_KEY_128_CHARS_LONG  --exact 1337________________________________C0DE

<snip>

Initialization time: 2 seconds
Hex string mask: 1337________________________________c0de

Running...
  Always verify that a private key generated by this program corresponds to the
  public key printed by importing it to a wallet of your choice. This program
  like any software might contain bugs and it does by design cut corners to
  improve overall performance.

  Time:     6s Private: 0x00003d93acbde69f615e498ccad72e653c18623564f35ee0899cee3965e8f7c8 Address: 0x13370b854805e1ed2e660d9e1c9a9a7346f1c0de
  Time:     8s Private: 0x00003d93acc639bf615e498ccad72e653c18623564f35ee0899cee3965e8f82f Address: 0x1337fce5c65a04659b925c3cb745c0cb74f9c0de
  Time:    20s Private: 0x00003d93acb92186615e498ccad72e653c18623564f35ee0899cee3965e8fb0c Address: 0x13370e9ae56041b7e0a89558fe4817074adec0de
Total: 515.328 MH/s - GPU0: 256.512 MH/s GPU1: 258.816 MH/s

```

Rationale: Output of`--match` mode is limited to 1 key per _score increase_, but producing some "close enough" results before full match happens. This is good for quick searches, but if you want to get more options, you have to restart `profanity2` each time.

`--exact` mode skip scoring system entirely, produces only exact matches but keeps giving out matches until cancelled. This will take more time than `--match` to get first results, but will give more choice without need to restart `profanity2`

Implementation: new  kernel `profanity_exact_match` treats `pResult` as circular buffer, reserving first element as write cursor position. On the host, when `exact` mode is set `m_memResult` handled as circular buffer as well, keeping read cursor position in Device struct.