### PR TITLE
Fix compilation for modern AMD GPUs (ROCm/OpenCL 3.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,6 @@ usage: ./profanity2 [OPTIONS]
 |Apple Silicon M1<br/>(8-core GPU)|-|-|-|45.0 MH/s| ~97s
 |Apple Silicon M1 Max<br/>(32-core GPU)|-|-|-|172.0 MH/s| ~25s
 |Apple Silicon M3 Pro<br/>(18-core GPU)|-|-|-|97 MH/s| ~45s
+|Apple Silicon M4 Max<br/>(40-core GPU)|-|-|-|350 MH/s| ~12s
 |Radeon AI PRO R9700 (Navi 48)|-|-|-|464 MH/s| ~9s
 |Radeon RX 7900 XTX (Navi 31)|-|-|-|520 MH/s| ~8s
-|Apple Silicon M4 Max<br/>(40-core GPU)|-|-|-|350 MH/s| ~12s
-

--- a/README.md
+++ b/README.md
@@ -127,5 +127,7 @@ usage: ./profanity2 [OPTIONS]
 |Apple Silicon M1<br/>(8-core GPU)|-|-|-|45.0 MH/s| ~97s
 |Apple Silicon M1 Max<br/>(32-core GPU)|-|-|-|172.0 MH/s| ~25s
 |Apple Silicon M3 Pro<br/>(18-core GPU)|-|-|-|97 MH/s| ~45s
+|Radeon AI PRO R9700 (Navi 48)|-|-|-|464 MH/s| ~9s
+|Radeon RX 7900 XTX (Navi 31)|-|-|-|520 MH/s| ~8s
 |Apple Silicon M4 Max<br/>(40-core GPU)|-|-|-|350 MH/s| ~12s
 

--- a/keccak.cl
+++ b/keccak.cl
@@ -125,7 +125,7 @@ __constant ulong keccakf_rndc[24] = {
 // Barely a bottleneck. No need to tinker more.
 void sha3_keccakf(ethhash * const h)
 {
-	ulong * const st = &h->q;
+	ulong * const st = (ulong * const)&h->q[0];
 	h->d[33] ^= 0x80000000;
 	ulong t0, t1, t2, t3, t4;
 

--- a/profanity.cl
+++ b/profanity.cl
@@ -693,7 +693,7 @@ void profanity_result_update(const size_t id, __global const uchar * const hash,
 
 __kernel void profanity_transform_contract(__global mp_number * const pInverse) {
 	const size_t id = get_global_id(0);
-	__global const uchar * const hash = pInverse[id].d;
+	__global const uchar * const hash = (__global const uchar *)&pInverse[id].d[0];
 
 	ethhash h;
 	for (int i = 0; i < 50; ++i) {
@@ -719,7 +719,7 @@ __kernel void profanity_transform_contract(__global mp_number * const pInverse) 
 
 __kernel void profanity_score_benchmark(__global mp_number * const pInverse, __global result * const pResult, __constant const uchar * const data1, __constant const uchar * const data2, const uchar scoreMax) {
 	const size_t id = get_global_id(0);
-	__global const uchar * const hash = pInverse[id].d;
+	__global const uchar * const hash = (__global const uchar *)&pInverse[id].d[0];
 	int score = 0;
 
 	profanity_result_update(id, hash, pResult, score, scoreMax);
@@ -727,7 +727,7 @@ __kernel void profanity_score_benchmark(__global mp_number * const pInverse, __g
 
 __kernel void profanity_score_matching(__global mp_number * const pInverse, __global result * const pResult, __constant const uchar * const data1, __constant const uchar * const data2, const uchar scoreMax) {
 	const size_t id = get_global_id(0);
-	__global const uchar * const hash = pInverse[id].d;
+	__global const uchar * const hash = (__global const uchar *)&pInverse[id].d[0];
 	int score = 0;
 
 	for (int i = 0; i < 20; ++i) {
@@ -741,7 +741,7 @@ __kernel void profanity_score_matching(__global mp_number * const pInverse, __gl
 
 __kernel void profanity_score_leading(__global mp_number * const pInverse, __global result * const pResult, __constant const uchar * const data1, __constant const uchar * const data2, const uchar scoreMax) {
 	const size_t id = get_global_id(0);
-	__global const uchar * const hash = pInverse[id].d;
+	__global const uchar * const hash = (__global const uchar *)&pInverse[id].d[0];
 	int score = 0;
 
 	for (int i = 0; i < 20; ++i) {
@@ -765,7 +765,7 @@ __kernel void profanity_score_leading(__global mp_number * const pInverse, __glo
 
 __kernel void profanity_score_range(__global mp_number * const pInverse, __global result * const pResult, __constant const uchar * const data1, __constant const uchar * const data2, const uchar scoreMax) {
 	const size_t id = get_global_id(0);
-	__global const uchar * const hash = pInverse[id].d;
+	__global const uchar * const hash = (__global const uchar *)&pInverse[id].d[0];
 	int score = 0;
 
 	for (int i = 0; i < 20; ++i) {
@@ -786,7 +786,7 @@ __kernel void profanity_score_range(__global mp_number * const pInverse, __globa
 
 __kernel void profanity_score_zerobytes(__global mp_number * const pInverse, __global result * const pResult, __constant const uchar * const data1, __constant const uchar * const data2, const uchar scoreMax) {
 	const size_t id = get_global_id(0);
-	__global const uchar * const hash = pInverse[id].d;
+	__global const uchar * const hash = (__global const uchar *)&pInverse[id].d[0];
 	int score = 0;
 
 	for (int i = 0; i < 20; ++i) {
@@ -800,7 +800,7 @@ __kernel void profanity_score_zerobytes(__global mp_number * const pInverse, __g
 
 __kernel void profanity_score_leadingrange(__global mp_number * const pInverse, __global result * const pResult, __constant const uchar * const data1, __constant const uchar * const data2, const uchar scoreMax) {
 	const size_t id = get_global_id(0);
-	__global const uchar * const hash = pInverse[id].d;
+	__global const uchar * const hash = (__global const uchar *)&pInverse[id].d[0];
 	int score = 0;
 
 	for (int i = 0; i < 20; ++i) {
@@ -827,7 +827,7 @@ __kernel void profanity_score_leadingrange(__global mp_number * const pInverse, 
 
 __kernel void profanity_score_mirror(__global mp_number * const pInverse, __global result * const pResult, __constant const uchar * const data1, __constant const uchar * const data2, const uchar scoreMax) {
 	const size_t id = get_global_id(0);
-	__global const uchar * const hash = pInverse[id].d;
+	__global const uchar * const hash = (__global const uchar *)&pInverse[id].d[0];
 	int score = 0;
 
 	for (int i = 0; i < 10; ++i) {
@@ -855,7 +855,7 @@ __kernel void profanity_score_mirror(__global mp_number * const pInverse, __glob
 
 __kernel void profanity_score_doubles(__global mp_number * const pInverse, __global result * const pResult, __constant const uchar * const data1, __constant const uchar * const data2, const uchar scoreMax) {
 	const size_t id = get_global_id(0);
-	__global const uchar * const hash = pInverse[id].d;
+	__global const uchar * const hash = (__global const uchar *)&pInverse[id].d[0];
 	int score = 0;
 
 	for (int i = 0; i < 20; ++i) {

--- a/profanity.cpp
+++ b/profanity.cpp
@@ -20,6 +20,23 @@
 #define CL_DEVICE_PCI_BUS_ID_NV  0x4008
 #define CL_DEVICE_PCI_SLOT_ID_NV 0x4009
 
+// AMD device topology struct (missing from some OpenCL headers)
+typedef struct _cl_device_topology_amd {
+    union {
+        struct {
+            unsigned int bus;
+            unsigned int device;
+            unsigned int function;
+        } pcie;
+        struct {
+            unsigned int type;
+            unsigned int data;
+        } raw;
+    };
+} cl_device_topology_amd;
+
+#define CL_DEVICE_TOPOLOGY_TYPE_PCIE_AMD  1
+
 #include "Dispatcher.hpp"
 #include "ArgParser.hpp"
 #include "Mode.hpp"


### PR DESCRIPTION
## Change Summary
**What does this PR change?**
Fix compilation for modern AMD GPUs (ROCm/OpenCL 3.0)
- Added missing cl_device_topology_amd struct definition for AMD device topology
- Fixed pointer casting issues in OpenCL kernels for type compatibility
- Now compiles successfully on ROCm-enabled AMD GPUs (Navi 31/48)
- Maintains full compatibility with original functionality
