### PR TITLE
Windows build support and build guides for Windows, Ubuntu and macOS

### DIFF
--- a/Dispatcher.cpp
+++ b/Dispatcher.cpp
@@ -12,6 +12,8 @@
 
 #if defined(__APPLE__) || defined(__MACOSX)
 #include <machine/endian.h>
+#elif defined(_WIN32)
+#include <winsock2.h>
 #else
 #include <arpa/inet.h>
 #endif

--- a/Makefile
+++ b/Makefile
@@ -2,15 +2,33 @@ CC=g++
 CDEFINES=
 SOURCES=Dispatcher.cpp Mode.cpp precomp.cpp profanity.cpp SpeedSample.cpp
 OBJECTS=$(SOURCES:.cpp=.o)
-EXECUTABLE=profanity2.x64
 
-UNAME_S := $(shell uname -s)
-ifeq ($(UNAME_S),Darwin)
-	LDFLAGS=-framework OpenCL
-	CFLAGS=-c -std=c++11 -Wall -O2
+# On Windows the OS environment variable is always set to Windows_NT.
+# Checking it first avoids calling `uname`, which is unavailable outside
+# of MSYS2/Cygwin shells (e.g. when using mingw32-make from cmd.exe).
+ifeq ($(OS),Windows_NT)
+	EXECUTABLE=profanity2.exe
+	# -mcmodel=large is not reliably supported by MinGW GCC on Windows
+	# targets, and htonl/ntohl live in ws2_32 there.
+	LDFLAGS=-s -lOpenCL -lws2_32
+	CFLAGS=-c -std=c++11 -Wall -mmmx -O2
+	# MSYSTEM is set inside MSYS2 shells, where unix commands are available.
+	ifdef MSYSTEM
+		RM=rm -f
+	else
+		RM=del /Q
+	endif
 else
-	LDFLAGS=-s -lOpenCL -mcmodel=large
-	CFLAGS=-c -std=c++11 -Wall -mmmx -O2 -mcmodel=large 
+	EXECUTABLE=profanity2.x64
+	RM=rm -f
+	UNAME_S := $(shell uname -s)
+	ifeq ($(UNAME_S),Darwin)
+		LDFLAGS=-framework OpenCL
+		CFLAGS=-c -std=c++11 -Wall -O2
+	else
+		LDFLAGS=-s -lOpenCL -mcmodel=large
+		CFLAGS=-c -std=c++11 -Wall -mmmx -O2 -mcmodel=large
+	endif
 endif
 
 all: $(SOURCES) $(EXECUTABLE)
@@ -22,5 +40,4 @@ $(EXECUTABLE): $(OBJECTS)
 	$(CC) $(CFLAGS) $(CDEFINES) $< -o $@
 
 clean:
-	rm -rf *.o
-
+	$(RM) *.o

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,11 @@ ifeq ($(OS),Windows_NT)
 	EXECUTABLE=profanity2.exe
 	# -mcmodel=large is not reliably supported by MinGW GCC on Windows
 	# targets, and htonl/ntohl live in ws2_32 there.
-	LDFLAGS=-s -lOpenCL -lws2_32
+	# -static bundles the MinGW runtimes (libstdc++, libgcc, winpthread) so
+	# the exe runs outside the MSYS2 shell; OpenCL.dll itself must stay
+	# dynamic (it is the system ICD loader), but with -static the linker
+	# skips .dll.a import libs for -lOpenCL, hence the explicit -l: name.
+	LDFLAGS=-s -static -l:libOpenCL.dll.a -lws2_32
 	CFLAGS=-c -std=c++11 -Wall -mmmx -O2
 	# MSYSTEM is set inside MSYS2 shells, where unix commands are available.
 	ifdef MSYSTEM

--- a/README.md
+++ b/README.md
@@ -52,6 +52,39 @@ sum (63 symbols):       bc7506af1b2484069d6ed3ea093c5123d83e2444d9c0a1cf277bf136
 private key (padded):  0bc7506af1b2484069d6ed3ea093c5123d83e2444d9c0a1cf277bf136fb46191
 ```
 
+# Building
+
+### macOS
+
+OpenCL ships with the system, so only the Xcode Command Line Tools are needed:
+
+```bash
+xcode-select --install   # skip if already installed
+make
+```
+
+This produces `profanity2.x64` in the repository root. Works on both Intel and
+Apple Silicon (M1/M2/M3/M4) Macs.
+
+### Ubuntu / Linux
+
+See [docs/BUILD_UBUNTU.md](docs/BUILD_UBUNTU.md). In short:
+
+```bash
+sudo apt install -y build-essential opencl-headers ocl-icd-opencl-dev clinfo
+make
+```
+
+plus the OpenCL runtime (driver) of your GPU vendor — the document covers
+NVIDIA/AMD/Intel setup and common errors.
+
+### Windows
+
+See [docs/BUILD_WINDOWS.md](docs/BUILD_WINDOWS.md) — building with MSYS2/MinGW-w64
+or against a vendor OpenCL SDK, plus troubleshooting for the most common errors
+(`CL/cl.h: No such file or directory`, `CreateProcess(NULL, uname -s, ...) failed`,
+empty device list, WSL2 limitations).
+
 # Usage
 ```
 usage: ./profanity2 [OPTIONS]

--- a/docs/BUILD_UBUNTU.md
+++ b/docs/BUILD_UBUNTU.md
@@ -89,13 +89,13 @@ parameter and for usage examples of all scoring modes.
 
 ## Troubleshooting
 
-| Symptom | Fix |
-|---|---|
-| `fatal error: CL/cl.h: No such file or directory` | `sudo apt install opencl-headers` |
-| `/usr/bin/ld: cannot find -lOpenCL` | `sudo apt install ocl-icd-opencl-dev` |
-| Output stops after `Devices:` (empty list) | No OpenCL runtime installed — see step 2, verify with `clinfo` |
-| Garbage device name, `unknown exception occured` | Broken/mismatched GPU driver — reinstall the vendor driver |
-| Works but private keys don't match addresses (AMD) | Update to a recent ROCm driver (see issue [#13](https://github.com/1inch/profanity2/issues/13)) |
+| Symptom | Fix | Seen in |
+|---|---|---|
+| `fatal error: CL/cl.h: No such file or directory` | `sudo apt install opencl-headers` | [#31](https://github.com/1inch/profanity2/issues/31) |
+| `/usr/bin/ld: cannot find -lOpenCL` | `sudo apt install ocl-icd-opencl-dev` | [#25](https://github.com/1inch/profanity2/issues/25) |
+| Output stops after `Devices:` (empty list) | No OpenCL runtime installed — see step 2, verify with `clinfo` | [#25](https://github.com/1inch/profanity2/issues/25), [#39](https://github.com/1inch/profanity2/issues/39), [#46](https://github.com/1inch/profanity2/issues/46) |
+| Garbage device name, `unknown exception occured` | Broken/mismatched GPU driver — reinstall the vendor driver | [#29](https://github.com/1inch/profanity2/issues/29) |
+| Works but private keys don't match addresses (AMD) | Update to a recent ROCm driver | [#13](https://github.com/1inch/profanity2/issues/13), [#5](https://github.com/1inch/profanity2/issues/5) |
 
 ## Credits
 

--- a/docs/BUILD_UBUNTU.md
+++ b/docs/BUILD_UBUNTU.md
@@ -96,3 +96,8 @@ parameter and for usage examples of all scoring modes.
 | Output stops after `Devices:` (empty list) | No OpenCL runtime installed — see step 2, verify with `clinfo` |
 | Garbage device name, `unknown exception occured` | Broken/mismatched GPU driver — reinstall the vendor driver |
 | Works but private keys don't match addresses (AMD) | Update to a recent ROCm driver (see issue [#13](https://github.com/1inch/profanity2/issues/13)) |
+
+## Credits
+
+This guide is based in part on the setup tips shared by [@umiiii](https://github.com/umiiii)
+in issue [#39](https://github.com/1inch/profanity2/issues/39) — thanks for the contribution!

--- a/docs/BUILD_UBUNTU.md
+++ b/docs/BUILD_UBUNTU.md
@@ -1,0 +1,98 @@
+# Building and running on Ubuntu / Linux
+
+These instructions are written for Ubuntu 20.04+, but apply to any Debian-like
+distribution. For other distributions replace `apt` packages with their
+equivalents.
+
+## 1. Install build dependencies
+
+```bash
+sudo apt update
+sudo apt install -y build-essential opencl-headers ocl-icd-opencl-dev clinfo
+```
+
+- `build-essential` — `g++` and `make`;
+- `opencl-headers` — the `CL/cl.h` header;
+- `ocl-icd-opencl-dev` — the `libOpenCL.so` loader that the binary links against (`-lOpenCL`);
+- `clinfo` — a diagnostic tool that lists available OpenCL devices.
+
+## 2. Install an OpenCL runtime for your GPU
+
+The packages above only provide the build-time dependencies. To actually *run*
+profanity2 you need the OpenCL driver (ICD) of your GPU vendor:
+
+### NVIDIA
+
+The proprietary NVIDIA driver already includes the OpenCL runtime:
+
+```bash
+sudo ubuntu-drivers install        # or: sudo apt install nvidia-driver-550
+```
+
+If devices still don't show up (common on cloud/headless instances), install the
+CUDA toolkit, which ships the OpenCL ICD as well:
+
+```bash
+sudo apt install -y nvidia-cuda-toolkit
+```
+
+On container platforms (Docker, RunPod, vast.ai etc.) make sure the OpenCL ICD is
+registered inside the container:
+
+```bash
+sudo mkdir -p /etc/OpenCL/vendors
+echo "libnvidia-opencl.so.1" | sudo tee /etc/OpenCL/vendors/nvidia.icd
+```
+
+### AMD
+
+Install a recent [ROCm](https://rocm.docs.amd.com/) release; old drivers are known to
+miscompile the OpenCL kernel and produce invalid keys (see issue
+[#13](https://github.com/1inch/profanity2/issues/13)):
+
+```bash
+sudo apt install -y rocm-opencl-runtime
+```
+
+### Intel (integrated graphics)
+
+```bash
+sudo apt install -y intel-opencl-icd
+```
+
+## 3. Verify OpenCL sees your GPU
+
+```bash
+clinfo
+```
+
+`clinfo` must list at least one platform and device. If it prints
+`Number of platforms 0`, profanity2 will not find any devices either — fix the
+driver installation first.
+
+## 4. Build
+
+```bash
+make
+```
+
+This produces the `profanity2.x64` executable in the repository root.
+
+## 5. Run
+
+```bash
+./profanity2.x64 --leading 0 -z HEX_PUBLIC_KEY_128_CHARS_LONG
+```
+
+See the [README](../README.md) for how to generate the public key for the `-z`
+parameter and for usage examples of all scoring modes.
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| `fatal error: CL/cl.h: No such file or directory` | `sudo apt install opencl-headers` |
+| `/usr/bin/ld: cannot find -lOpenCL` | `sudo apt install ocl-icd-opencl-dev` |
+| Output stops after `Devices:` (empty list) | No OpenCL runtime installed — see step 2, verify with `clinfo` |
+| Garbage device name, `unknown exception occured` | Broken/mismatched GPU driver — reinstall the vendor driver |
+| Works but private keys don't match addresses (AMD) | Update to a recent ROCm driver (see issue [#13](https://github.com/1inch/profanity2/issues/13)) |

--- a/docs/BUILD_WINDOWS.md
+++ b/docs/BUILD_WINDOWS.md
@@ -79,10 +79,10 @@ profanity2 will print an empty device list. Build natively with MSYS2 instead.
 
 ## Troubleshooting
 
-| Symptom | Fix |
-|---|---|
-| `fatal error: CL/cl.h: No such file or directory` | OpenCL headers not installed / not in include path — see steps above |
-| `process_begin: CreateProcess(NULL, uname -s, ...) failed` | You ran `make` outside an MSYS2 shell; use the MSYS2 UCRT64 shell or the direct `g++` command |
-| `cannot find -lOpenCL` | Install `mingw-w64-ucrt-x86_64-opencl-icd` or pass `-L<path to OpenCL.lib/libOpenCL.dll.a>` |
-| Output stops after `Devices:` (empty list) | Install/update your GPU driver; don't run under WSL2 |
-| `error: code model 'large' not supported` | Build without `-mcmodel=large` (see the note in step 3) |
+| Symptom | Fix | Seen in |
+|---|---|---|
+| `fatal error: CL/cl.h: No such file or directory` | OpenCL headers not installed / not in include path — see steps above | [#31](https://github.com/1inch/profanity2/issues/31), [#27](https://github.com/1inch/profanity2/issues/27), [#23](https://github.com/1inch/profanity2/issues/23), [#20](https://github.com/1inch/profanity2/issues/20) |
+| `process_begin: CreateProcess(NULL, uname -s, ...) failed` | You ran `make` outside an MSYS2 shell; use the MSYS2 UCRT64 shell or the direct `g++` command | [#26](https://github.com/1inch/profanity2/issues/26), [#21](https://github.com/1inch/profanity2/issues/21) |
+| `cannot find -lOpenCL` | Install `mingw-w64-ucrt-x86_64-opencl-icd` or pass `-L<path to OpenCL.lib/libOpenCL.dll.a>` | |
+| Output stops after `Devices:` (empty list) | Install/update your GPU driver; don't run under WSL2 | [#17](https://github.com/1inch/profanity2/issues/17) |
+| `error: code model 'large' not supported` | Build without `-mcmodel=large` (see the note in step 3) | |

--- a/docs/BUILD_WINDOWS.md
+++ b/docs/BUILD_WINDOWS.md
@@ -1,0 +1,88 @@
+# Building and running on Windows
+
+The repository ships with a `Makefile` written for Unix-like environments, so the
+easiest way to build on Windows is the [MSYS2](https://www.msys2.org/) environment,
+which provides `g++`, `make` and prebuilt OpenCL packages. Plain MinGW or `g++`
+called from `cmd.exe`/Git Bash will fail with errors like
+`CL/cl.h: No such file or directory` or
+`process_begin: CreateProcess(NULL, uname -s, ...) failed` — use MSYS2 instead.
+
+## Option A (recommended): MSYS2 / MinGW-w64
+
+### 1. Install MSYS2
+
+Download and install from [msys2.org](https://www.msys2.org/), then open the
+**"MSYS2 UCRT64"** shell (not the plain "MSYS2 MSYS" one).
+
+### 2. Install the toolchain and OpenCL packages
+
+```bash
+pacman -Syu
+pacman -S --needed make mingw-w64-ucrt-x86_64-gcc \
+                   mingw-w64-ucrt-x86_64-opencl-headers \
+                   mingw-w64-ucrt-x86_64-opencl-icd
+```
+
+- `opencl-headers` provides `CL/cl.h`;
+- `opencl-icd` provides the import library for `OpenCL.dll`, the system OpenCL
+  loader that dispatches to your GPU driver at runtime.
+
+### 3. Build
+
+From the repository root inside the UCRT64 shell:
+
+```bash
+g++ -std=c++11 -Wall -O2 Dispatcher.cpp Mode.cpp precomp.cpp profanity.cpp SpeedSample.cpp \
+    -lOpenCL -o profanity2.exe
+```
+
+> Note: the stock `Makefile` passes `-mcmodel=large`, which some MinGW builds of
+> GCC do not support. The direct command above builds the same sources without it;
+> alternatively run `make CFLAGS="-c -std=c++11 -Wall -O2" LDFLAGS="-lOpenCL -s" EXECUTABLE=profanity2.exe`.
+
+### 4. Run
+
+Your GPU driver must be installed (NVIDIA and AMD drivers include the OpenCL
+runtime on Windows). Then:
+
+```bash
+./profanity2.exe --leading 0 -z HEX_PUBLIC_KEY_128_CHARS_LONG
+```
+
+If you launch `profanity2.exe` outside the MSYS2 shell (e.g. from Explorer or
+`cmd.exe`) and get missing-DLL errors, copy the required runtime DLLs
+(`libstdc++-6.dll`, `libgcc_s_seh-1.dll`, `libwinpthread-1.dll`) from
+`C:\msys64\ucrt64\bin` next to the executable, or link statically by adding
+`-static` to the build command.
+
+## Option B: linking against a vendor OpenCL SDK
+
+If you prefer not to install the MSYS2 OpenCL packages, any vendor OpenCL SDK
+works, e.g. the [CUDA Toolkit](https://developer.nvidia.com/cuda-downloads)
+(NVIDIA) or the [OpenCL SDK](https://github.com/KhronosGroup/OpenCL-SDK/releases)
+(any vendor). Point the compiler at the SDK's include and library directories:
+
+```bash
+g++ -std=c++11 -Wall -O2 \
+    -I"C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v12.4/include" \
+    -L"C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v12.4/lib/x64" \
+    Dispatcher.cpp Mode.cpp precomp.cpp profanity.cpp SpeedSample.cpp \
+    -lOpenCL -o profanity2.exe
+```
+
+## What about WSL2?
+
+Building under WSL2 works (follow the [Ubuntu instructions](BUILD_UBUNTU.md)), but
+**GPU OpenCL devices are generally not available inside WSL2** — the GPU
+paravirtualization exposes CUDA/DirectML but not a full OpenCL stack, so
+profanity2 will print an empty device list. Build natively with MSYS2 instead.
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| `fatal error: CL/cl.h: No such file or directory` | OpenCL headers not installed / not in include path — see steps above |
+| `process_begin: CreateProcess(NULL, uname -s, ...) failed` | You ran `make` outside an MSYS2 shell; use the MSYS2 UCRT64 shell or the direct `g++` command |
+| `cannot find -lOpenCL` | Install `mingw-w64-ucrt-x86_64-opencl-icd` or pass `-L<path to OpenCL.lib/libOpenCL.dll.a>` |
+| Output stops after `Devices:` (empty list) | Install/update your GPU driver; don't run under WSL2 |
+| `error: code model 'large' not supported` | Build without `-mcmodel=large` (see the note in step 3) |

--- a/docs/BUILD_WINDOWS.md
+++ b/docs/BUILD_WINDOWS.md
@@ -36,13 +36,20 @@ make
 ```
 
 The `Makefile` detects Windows automatically (via the `OS=Windows_NT` environment
-variable) and produces `profanity2.exe`. If you prefer to build without `make`,
-the equivalent direct command is:
+variable) and produces `profanity2.exe`. The MinGW runtimes (`libstdc++`, `libgcc`,
+`winpthread`) are linked statically, so the resulting exe is self-contained and
+runs outside the MSYS2 shell — only `OpenCL.dll` is loaded dynamically, and that
+one ships with your GPU driver.
+
+If you prefer to build without `make`, the equivalent direct command is:
 
 ```bash
 g++ -std=c++11 -Wall -O2 Dispatcher.cpp Mode.cpp precomp.cpp profanity.cpp SpeedSample.cpp \
-    -lOpenCL -lws2_32 -o profanity2.exe
+    -static -l:libOpenCL.dll.a -lws2_32 -o profanity2.exe
 ```
+
+(`-l:libOpenCL.dll.a` names the OpenCL import library explicitly because with
+`-static` the linker would otherwise skip `.dll.a` files when resolving `-lOpenCL`.)
 
 ### 4. Run
 
@@ -53,11 +60,12 @@ runtime on Windows). Then:
 ./profanity2.exe --leading 0 -z HEX_PUBLIC_KEY_128_CHARS_LONG
 ```
 
-If you launch `profanity2.exe` outside the MSYS2 shell (e.g. from Explorer or
-`cmd.exe`) and get missing-DLL errors, copy the required runtime DLLs
-(`libstdc++-6.dll`, `libgcc_s_seh-1.dll`, `libwinpthread-1.dll`) from
-`C:\msys64\ucrt64\bin` next to the executable, or link statically by adding
-`-static` to the build command.
+The executable is statically linked against the MinGW runtimes, so it can be
+launched from anywhere (Explorer, `cmd.exe`, PowerShell) — no extra DLLs needed.
+If you built with a custom command without `-static` and get missing-DLL errors
+outside the MSYS2 shell, either add `-static` or copy `libstdc++-6.dll`,
+`libgcc_s_seh-1.dll` and `libwinpthread-1.dll` from `C:\msys64\ucrt64\bin` next
+to the executable.
 
 ### 5. Generating the seed public key for `-z`
 

--- a/docs/BUILD_WINDOWS.md
+++ b/docs/BUILD_WINDOWS.md
@@ -59,6 +59,24 @@ If you launch `profanity2.exe` outside the MSYS2 shell (e.g. from Explorer or
 `C:\msys64\ucrt64\bin` next to the executable, or link statically by adding
 `-static` to the build command.
 
+### 5. Generating the seed public key for `-z`
+
+Windows does not ship `openssl`, and the key-generation one-liners in the
+[README](../README.md#getting-public-key-for-mandatory--z-parameter) also need
+`xxd` and `sed`, so run them from a Unix-like shell:
+
+- **MSYS2** (same shell you build in): install the missing tools first —
+
+  ```bash
+  pacman -S --needed openssl vim   # vim provides xxd
+  ```
+
+- **Git Bash** ([Git for Windows](https://git-scm.com/download/win)): `openssl`,
+  `xxd` and `sed` are already bundled, the README commands work as-is.
+
+As always: generate the key locally, never share the private key and never use
+online key generators or calculators.
+
 ## Option B: linking against a vendor OpenCL SDK
 
 If you prefer not to install the MSYS2 OpenCL packages, any vendor OpenCL SDK

--- a/docs/BUILD_WINDOWS.md
+++ b/docs/BUILD_WINDOWS.md
@@ -1,11 +1,11 @@
 # Building and running on Windows
 
-The repository ships with a `Makefile` written for Unix-like environments, so the
-easiest way to build on Windows is the [MSYS2](https://www.msys2.org/) environment,
-which provides `g++`, `make` and prebuilt OpenCL packages. Plain MinGW or `g++`
-called from `cmd.exe`/Git Bash will fail with errors like
-`CL/cl.h: No such file or directory` or
-`process_begin: CreateProcess(NULL, uname -s, ...) failed` — use MSYS2 instead.
+The `Makefile` supports Windows out of the box: it detects the platform and builds
+`profanity2.exe`. What it cannot do for you is provide a compiler and the OpenCL
+headers/libraries — bare `g++` from `cmd.exe`/Git Bash without them fails with
+errors like `CL/cl.h: No such file or directory`. The easiest way to get a complete
+toolchain is the [MSYS2](https://www.msys2.org/) environment, which provides `g++`,
+`make` and prebuilt OpenCL packages.
 
 ## Option A (recommended): MSYS2 / MinGW-w64
 
@@ -32,13 +32,17 @@ pacman -S --needed make mingw-w64-ucrt-x86_64-gcc \
 From the repository root inside the UCRT64 shell:
 
 ```bash
-g++ -std=c++11 -Wall -O2 Dispatcher.cpp Mode.cpp precomp.cpp profanity.cpp SpeedSample.cpp \
-    -lOpenCL -o profanity2.exe
+make
 ```
 
-> Note: the stock `Makefile` passes `-mcmodel=large`, which some MinGW builds of
-> GCC do not support. The direct command above builds the same sources without it;
-> alternatively run `make CFLAGS="-c -std=c++11 -Wall -O2" LDFLAGS="-lOpenCL -s" EXECUTABLE=profanity2.exe`.
+The `Makefile` detects Windows automatically (via the `OS=Windows_NT` environment
+variable) and produces `profanity2.exe`. If you prefer to build without `make`,
+the equivalent direct command is:
+
+```bash
+g++ -std=c++11 -Wall -O2 Dispatcher.cpp Mode.cpp precomp.cpp profanity.cpp SpeedSample.cpp \
+    -lOpenCL -lws2_32 -o profanity2.exe
+```
 
 ### 4. Run
 
@@ -67,7 +71,14 @@ g++ -std=c++11 -Wall -O2 \
     -I"C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v12.4/include" \
     -L"C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v12.4/lib/x64" \
     Dispatcher.cpp Mode.cpp precomp.cpp profanity.cpp SpeedSample.cpp \
-    -lOpenCL -o profanity2.exe
+    -lOpenCL -lws2_32 -o profanity2.exe
+```
+
+The same works through `make`:
+
+```bash
+make CDEFINES='-I"C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v12.4/include"' \
+     LDFLAGS='-s -L"C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v12.4/lib/x64" -lOpenCL -lws2_32'
 ```
 
 ## What about WSL2?
@@ -82,7 +93,6 @@ profanity2 will print an empty device list. Build natively with MSYS2 instead.
 | Symptom | Fix | Seen in |
 |---|---|---|
 | `fatal error: CL/cl.h: No such file or directory` | OpenCL headers not installed / not in include path — see steps above | [#31](https://github.com/1inch/profanity2/issues/31), [#27](https://github.com/1inch/profanity2/issues/27), [#23](https://github.com/1inch/profanity2/issues/23), [#20](https://github.com/1inch/profanity2/issues/20) |
-| `process_begin: CreateProcess(NULL, uname -s, ...) failed` | You ran `make` outside an MSYS2 shell; use the MSYS2 UCRT64 shell or the direct `g++` command | [#26](https://github.com/1inch/profanity2/issues/26), [#21](https://github.com/1inch/profanity2/issues/21) |
+| `process_begin: CreateProcess(NULL, uname -s, ...) failed` | You are on an old checkout whose `Makefile` called `uname` on Windows — update to latest `master` | [#26](https://github.com/1inch/profanity2/issues/26), [#21](https://github.com/1inch/profanity2/issues/21) |
 | `cannot find -lOpenCL` | Install `mingw-w64-ucrt-x86_64-opencl-icd` or pass `-L<path to OpenCL.lib/libOpenCL.dll.a>` | |
 | Output stops after `Devices:` (empty list) | Install/update your GPU driver; don't run under WSL2 | [#17](https://github.com/1inch/profanity2/issues/17) |
-| `error: code model 'large' not supported` | Build without `-mcmodel=large` (see the note in step 3) | |

--- a/profanity.cpp
+++ b/profanity.cpp
@@ -136,7 +136,10 @@ std::vector<std::string> getBinaries(cl_program & clProgram) {
 }
 
 unsigned int getUniqueDeviceIdentifier(const cl_device_id & deviceId) {
-#if defined(CL_DEVICE_TOPOLOGY_AMD)
+	// Recent Khronos headers define CL_DEVICE_TOPOLOGY_AMD but dropped the
+	// cl_device_topology_amd struct and the TYPE_PCIE constant, hence the
+	// second condition.
+#if defined(CL_DEVICE_TOPOLOGY_AMD) && defined(CL_DEVICE_TOPOLOGY_TYPE_PCIE_AMD)
 	auto topology = clGetWrapper<cl_device_topology_amd>(clGetDeviceInfo, deviceId, CL_DEVICE_TOPOLOGY_AMD);
 	if (topology.raw.type == CL_DEVICE_TOPOLOGY_TYPE_PCIE_AMD) {
 		return (topology.pcie.bus << 16) + (topology.pcie.device << 8) + topology.pcie.function;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Two things in this PR: **build documentation** for all three platforms, and **Windows build support** — `make` now works on Windows out of the box and produces a self-contained static `profanity2.exe`.

### 1. Build documentation

- **README — new "Building" section**: short macOS instruction inline (OpenCL ships with the system, so it's just `xcode-select --install` + `make`; works on Intel and Apple Silicon), plus links to the platform guides below.
- **`docs/BUILD_UBUNTU.md`**: required apt packages (`build-essential`, `opencl-headers`, `ocl-icd-opencl-dev`, `clinfo`), how to install the OpenCL runtime for NVIDIA / AMD / Intel GPUs (including containers like RunPod/vast.ai), verification with `clinfo`, and a troubleshooting table where each entry links to the issue(s) it was reported in. Credits @umiiii for the setup tips from #39.
- **`docs/BUILD_WINDOWS.md`**: building with MSYS2/MinGW-w64 (recommended) or against a vendor OpenCL SDK (CUDA Toolkit / Khronos SDK), generating the `-z` seed public key on Windows (MSYS2 `openssl` + `xxd`, or Git Bash where everything is bundled), WSL2 limitations (no OpenCL devices), and a troubleshooting table with issue links.

### 2. Windows build support

- **`Makefile`**:
  - detects Windows via the `OS=Windows_NT` environment variable instead of calling `uname`, which failed with `process_begin: CreateProcess(NULL, uname -s, ...) failed` (#26, #21), and builds `profanity2.exe`;
  - links the MinGW runtimes (`libstdc++`, `libgcc`, `winpthread`) statically via `-static`, so the exe runs from anywhere (Explorer/cmd/PowerShell) with no MSYS2 DLLs. Only `OpenCL.dll` stays dynamic — it's the system ICD loader shipped with GPU drivers. It is referenced explicitly as `-l:libOpenCL.dll.a` because `-static` makes the linker skip `.dll.a` import libs for plain `-lOpenCL`;
  - drops `-mcmodel=large` on Windows (not reliably supported by MinGW GCC) and links `ws2_32`;
  - `clean` uses `rm` or `del` depending on the shell (MSYS2 vs cmd.exe).
- **`Dispatcher.cpp`**: include `winsock2.h` on Windows for `htonl` — `arpa/inet.h` doesn't exist there.
- **`profanity.cpp`**: guard the AMD PCIe topology query on `CL_DEVICE_TOPOLOGY_TYPE_PCIE_AMD` in addition to `CL_DEVICE_TOPOLOGY_AMD` — recent Khronos headers (shipped by MSYS2 and the Khronos SDK) define the latter macro but dropped the `cl_device_topology_amd` struct, which broke compilation.

## Verification

- **Ubuntu**: in a clean environment, installing exactly the packages listed in the guide and running `make` produces a working `profanity2.x64` (help output verified). Linux link flags are unchanged.
- **Windows**: cross-compiled all sources with `x86_64-w64-mingw32-g++` and current Khronos OpenCL headers through the Makefile's Windows branch (`OS=Windows_NT`), linked a valid PE32+ `profanity2.exe`; `objdump -p` confirms the only dependencies are `OpenCL.dll`, `KERNEL32.dll`, `msvcrt.dll`, `WS2_32.dll` — no MinGW runtime DLLs. Not run on real Windows hardware — worth a smoke test in MSYS2 if available.

## Motivation

Build problems are the single biggest source of issues in this repo. After merging, the following can be answered with a link and closed:

- Windows: #31, #27, #26, #23, #21, #20, #19, #14
- Ubuntu: #25, #39 (incorporates the tips contributed there — thanks @umiiii)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-298d1fec-3dba-4951-9533-5169b09bef82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-298d1fec-3dba-4951-9533-5169b09bef82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

