### PR TITLE
Fix incompatible pointer casts in OpenCL kernels for strict compilers (ROCm)

### DIFF
--- a/keccak.cl
+++ b/keccak.cl
@@ -125,7 +125,7 @@ __constant ulong keccakf_rndc[24] = {
 // Barely a bottleneck. No need to tinker more.
 void sha3_keccakf(ethhash * const h)
 {
-	ulong * const st = &h->q;
+	ulong * const st = (ulong * const)&h->q[0];
 	h->d[33] ^= 0x80000000;
 	ulong t0, t1, t2, t3, t4;
 

--- a/profanity.cl
+++ b/profanity.cl
@@ -713,7 +713,7 @@ void profanity_result_update(const size_t id, __global const uchar * const hash,
 
 __kernel void profanity_transform_contract(__global mp_number * const pInverse) {
 	const size_t id = get_global_id(0);
-	__global const uchar * const hash = pInverse[id].d;
+	__global const uchar * const hash = (__global const uchar *)&pInverse[id].d[0];
 
 	ethhash h;
 	for (int i = 0; i < 50; ++i) {
@@ -739,7 +739,7 @@ __kernel void profanity_transform_contract(__global mp_number * const pInverse) 
 
 __kernel void profanity_score_benchmark(__global mp_number * const pInverse, __global result * const pResult, __constant const uchar * const data1, __constant const uchar * const data2, const uchar scoreMax) {
 	const size_t id = get_global_id(0);
-	__global const uchar * const hash = pInverse[id].d;
+	__global const uchar * const hash = (__global const uchar *)&pInverse[id].d[0];
 	int score = 0;
 
 	profanity_result_update(id, hash, pResult, score, scoreMax);
@@ -747,7 +747,7 @@ __kernel void profanity_score_benchmark(__global mp_number * const pInverse, __g
 
 __kernel void profanity_score_matching(__global mp_number * const pInverse, __global result * const pResult, __constant const uchar * const data1, __constant const uchar * const data2, const uchar scoreMax) {
 	const size_t id = get_global_id(0);
-	__global const uchar * const hash = pInverse[id].d;
+	__global const uchar * const hash = (__global const uchar *)&pInverse[id].d[0];
 	int score = 0;
 
 	for (int i = 0; i < 20; ++i) {
@@ -761,7 +761,7 @@ __kernel void profanity_score_matching(__global mp_number * const pInverse, __gl
 
 __kernel void profanity_score_leading(__global mp_number * const pInverse, __global result * const pResult, __constant const uchar * const data1, __constant const uchar * const data2, const uchar scoreMax) {
 	const size_t id = get_global_id(0);
-	__global const uchar * const hash = pInverse[id].d;
+	__global const uchar * const hash = (__global const uchar *)&pInverse[id].d[0];
 	int score = 0;
 
 	for (int i = 0; i < 20; ++i) {
@@ -785,7 +785,7 @@ __kernel void profanity_score_leading(__global mp_number * const pInverse, __glo
 
 __kernel void profanity_score_range(__global mp_number * const pInverse, __global result * const pResult, __constant const uchar * const data1, __constant const uchar * const data2, const uchar scoreMax) {
 	const size_t id = get_global_id(0);
-	__global const uchar * const hash = pInverse[id].d;
+	__global const uchar * const hash = (__global const uchar *)&pInverse[id].d[0];
 	int score = 0;
 
 	for (int i = 0; i < 20; ++i) {
@@ -806,7 +806,7 @@ __kernel void profanity_score_range(__global mp_number * const pInverse, __globa
 
 __kernel void profanity_score_zerobytes(__global mp_number * const pInverse, __global result * const pResult, __constant const uchar * const data1, __constant const uchar * const data2, const uchar scoreMax) {
 	const size_t id = get_global_id(0);
-	__global const uchar * const hash = pInverse[id].d;
+	__global const uchar * const hash = (__global const uchar *)&pInverse[id].d[0];
 	int score = 0;
 
 	for (int i = 0; i < 20; ++i) {
@@ -820,7 +820,7 @@ __kernel void profanity_score_zerobytes(__global mp_number * const pInverse, __g
 
 __kernel void profanity_score_leadingrange(__global mp_number * const pInverse, __global result * const pResult, __constant const uchar * const data1, __constant const uchar * const data2, const uchar scoreMax) {
 	const size_t id = get_global_id(0);
-	__global const uchar * const hash = pInverse[id].d;
+	__global const uchar * const hash = (__global const uchar *)&pInverse[id].d[0];
 	int score = 0;
 
 	for (int i = 0; i < 20; ++i) {
@@ -847,7 +847,7 @@ __kernel void profanity_score_leadingrange(__global mp_number * const pInverse, 
 
 __kernel void profanity_score_mirror(__global mp_number * const pInverse, __global result * const pResult, __constant const uchar * const data1, __constant const uchar * const data2, const uchar scoreMax) {
 	const size_t id = get_global_id(0);
-	__global const uchar * const hash = pInverse[id].d;
+	__global const uchar * const hash = (__global const uchar *)&pInverse[id].d[0];
 	int score = 0;
 
 	for (int i = 0; i < 10; ++i) {
@@ -875,7 +875,7 @@ __kernel void profanity_score_mirror(__global mp_number * const pInverse, __glob
 
 __kernel void profanity_score_doubles(__global mp_number * const pInverse, __global result * const pResult, __constant const uchar * const data1, __constant const uchar * const data2, const uchar scoreMax) {
 	const size_t id = get_global_id(0);
-	__global const uchar * const hash = pInverse[id].d;
+	__global const uchar * const hash = (__global const uchar *)&pInverse[id].d[0];
 	int score = 0;
 
 	for (int i = 0; i < 20; ++i) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Change Summary

Cherry-picks the kernel-side portion of #48 (credit: @fala13) onto current master, so profanity2's OpenCL kernels compile on strict clang-based runtime compilers such as ROCm on modern AMD GPUs (Navi 31/48) and PoCL.

**What was broken**

The OpenCL C sources contained two ill-typed pointer initializations that older/lenient compilers accepted but modern clang-based ones reject at runtime kernel compilation:

- `keccak.cl`: `ulong * const st = &h->q;` — `&h->q` has type `ulong (*)[25]`, not `ulong *`.
- `profanity.cl` (9 occurrences): `__global const uchar * const hash = pInverse[id].d;` — implicit conversion from `__global uint[8]` to `__global const uchar *`.

**What this PR does**

Makes the reinterpretations explicit with casts (`(ulong * const)&h->q[0]` and `(__global const uchar *)&pInverse[id].d[0]`). The generated byte-level access pattern is bit-for-bit identical to the previous behavior — no functional change.

**Verification**

- Old kernels fail `clBuildProgram` with `-Werror` on PoCL (clang 18) with 10 `incompatible pointer types` errors; fixed kernels build clean (also syntax-checked with `clang -x cl` under both `-cl-std=CL1.2` and `CL3.0`).
- `tests/test_correctness_pr49.x64` passes on PoCL: all mp-math cases OK.
- Host binary builds unchanged on Ubuntu 24.04 with Khronos `opencl-headers 3.0~2023.12.14`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-791594a7-a32b-455c-9685-3c5ac47aa229"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-791594a7-a32b-455c-9685-3c5ac47aa229"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

