### PR TITLE
Add --exact mode that prints every address matching a hex mask

### DIFF
--- a/CLMemory.hpp
+++ b/CLMemory.hpp
@@ -51,6 +51,17 @@ template<typename T> class CLMemory {
 			}
 		}
 
+		// Writes a region of the device buffer from an external host pointer
+		// instead of the internal one. For a non-blocking write the source
+		// must stay valid until the command has executed.
+		void writeRegion(const bool bBlock, const size_t offset, const size_t size, const void * const pSource) const {
+			const cl_bool block = bBlock ? CL_TRUE : CL_FALSE;
+			auto res = clEnqueueWriteBuffer(m_clQueue, m_clMem, block, offset, size, pSource, 0, NULL, NULL);
+			if( res != CL_SUCCESS ) {
+				throw std::runtime_error("clEnqueueWriteBuffer failed - " + toString(res));
+			}
+		}
+
 		T * const & data() const {
 			return m_pData;
 		}

--- a/Dispatcher.cpp
+++ b/Dispatcher.cpp
@@ -98,7 +98,14 @@ static void printResult(cl_ulong4 seed, cl_ulong round, result r, cl_uchar score
 
 	// Print
 	const std::string strVT100ClearLine = "\33[2K\r";
-	std::cout << strVT100ClearLine << "  Time: " << std::setw(5) << seconds << "s Score: " << std::setw(2) << (int) score << " Private: 0x" << strPrivate << ' ';
+	std::cout << strVT100ClearLine << "  Time: " << std::setw(5) << seconds << "s";
+
+	// Exact mode has no scoring, every result is a full match
+	if (mode.name != "exact") {
+		std::cout << " Score: " << std::setw(2) << (int) score;
+	}
+
+	std::cout << " Private: 0x" << strPrivate << ' ';
 
 	std::cout << mode.transformName();
 	std::cout << ": 0x" << strPublic << std::endl;
@@ -405,6 +412,14 @@ void Dispatcher::dispatch(Device & d) {
 	cl_event event;
 	d.m_memResult.read(false, &event);
 
+	if (m_mode.name == "exact") {
+		// Reset the match counter before this round's kernel appends new
+		// results. The in-order queue guarantees this write executes after
+		// the read above has captured the previous round's results.
+		static const cl_uint zero = 0;
+		d.m_memResult.writeRegion(false, 0, sizeof(zero), &zero);
+	}
+
 #ifdef PROFANITY_DEBUG
 	cl_event eventInverse;
 	cl_event eventIterate;
@@ -435,7 +450,36 @@ void Dispatcher::dispatch(Device & d) {
 	OpenCLException::throwIfError("failed to set custom callback", res);
 }
 
+// In exact mode the kernel appends every full match to the result buffer:
+// element [0] holds the number of matches found during the last round and
+// elements [1..PROFANITY_MAX_SCORE] hold the matches themselves. The counter
+// is reset before every round (see dispatch()), so everything in the buffer
+// is new and can be printed as-is.
+void Dispatcher::handleExactResult(Device & d) {
+	const cl_uint count = d.m_memResult[0].found;
+	if (count == 0) {
+		return;
+	}
+
+	const cl_uint stored = count < PROFANITY_MAX_SCORE ? count : PROFANITY_MAX_SCORE;
+
+	std::lock_guard<std::mutex> lock(m_mutex);
+	for (cl_uint i = 0; i < stored; ++i) {
+		printResult(d.m_clSeed, d.m_round, d.m_memResult[i + 1], 0, timeStart, m_mode);
+	}
+
+	if (count > stored) {
+		const std::string strVT100ClearLine = "\33[2K\r";
+		std::cout << strVT100ClearLine << "  warning: " << (count - stored) << " additional matches were found this round but did not fit the result buffer (" << PROFANITY_MAX_SCORE << " entries); use a more specific mask" << std::endl;
+	}
+}
+
 void Dispatcher::handleResult(Device & d) {
+	if (m_mode.name == "exact") {
+		handleExactResult(d);
+		return;
+	}
+
 	for (auto i = PROFANITY_MAX_SCORE; i > m_clScoreMax; --i) {
 		result & r = d.m_memResult[i];
 

--- a/Dispatcher.cpp
+++ b/Dispatcher.cpp
@@ -192,7 +192,9 @@ Dispatcher::Device::Device(Dispatcher & parent, cl_context & clContext, cl_progr
 	m_memPointsDeltaX(clContext, m_clQueue, CL_MEM_READ_WRITE | CL_MEM_HOST_NO_ACCESS, size, true),
 	m_memInversedNegativeDoubleGy(clContext, m_clQueue, CL_MEM_READ_WRITE | CL_MEM_HOST_NO_ACCESS, size, true),
 	m_memPrevLambda(clContext, m_clQueue, CL_MEM_READ_WRITE | CL_MEM_HOST_NO_ACCESS, size, true),
-	m_memResult(clContext, m_clQueue, CL_MEM_READ_WRITE | CL_MEM_HOST_READ_ONLY, PROFANITY_MAX_SCORE + 1),
+	// Exact mode resets the match counter in the result buffer from the host
+	// before every round, which CL_MEM_HOST_READ_ONLY would forbid.
+	m_memResult(clContext, m_clQueue, mode.name == "exact" ? CL_MEM_READ_WRITE : CL_MEM_READ_WRITE | CL_MEM_HOST_READ_ONLY, PROFANITY_MAX_SCORE + 1),
 	m_memData1(clContext, m_clQueue, CL_MEM_READ_ONLY | CL_MEM_HOST_WRITE_ONLY, 20),
 	m_memData2(clContext, m_clQueue, CL_MEM_READ_ONLY | CL_MEM_HOST_WRITE_ONLY, 20),
 	m_clSeed(createSeed()),

--- a/Dispatcher.hpp
+++ b/Dispatcher.hpp
@@ -96,6 +96,7 @@ class Dispatcher {
 		void enqueueKernelDevice(Device & d, cl_kernel & clKernel, size_t worksizeGlobal, cl_event * pEvent);
 
 		void handleResult(Device & d);
+		void handleExactResult(Device & d);
 		void randomizeSeed(Device & d);
 
 		void onEvent(cl_event event, cl_int status, Device & d);

--- a/Mode.cpp
+++ b/Mode.cpp
@@ -42,6 +42,10 @@ Mode Mode::matching(const std::string strHex) {
 	r.name = "matching";
 	r.kernel = "profanity_score_matching";
 
+	if (strHex.size() > 40) {
+		throw std::runtime_error("hex mask must be at most 40 characters, got " + std::to_string(strHex.size()));
+	}
+
 	std::fill( r.data1, r.data1 + sizeof(r.data1), cl_uchar(0) );
 	std::fill( r.data2, r.data2 + sizeof(r.data2), cl_uchar(0) );
 
@@ -63,6 +67,13 @@ Mode Mode::matching(const std::string strHex) {
 		++index;
 	}
 
+	return r;
+}
+
+Mode Mode::exact(const std::string strHex) {
+	Mode r = matching(strHex);
+	r.name = "exact";
+	r.kernel = "profanity_exact_match";
 	return r;
 }
 

--- a/Mode.hpp
+++ b/Mode.hpp
@@ -21,6 +21,7 @@ class Mode {
 
 	public:
 		static Mode matching(const std::string strHex);
+		static Mode exact(const std::string strHex);
 		static Mode range(const cl_uchar min, const cl_uchar max);
 		static Mode leading(const char charLeading);
 		static Mode leadingRange(const cl_uchar min, const cl_uchar max);

--- a/README.md
+++ b/README.md
@@ -105,6 +105,9 @@ usage: ./profanity2 [OPTIONS]
   Modes with arguments:
     --leading <single hex>  Score on hashes leading with given hex character.
     --matching <hex string> Score on hashes matching given hex string.
+    -e, --exact <hex mask>  Print every hash matching the given mask exactly,
+                            not just the best one. Non-hex characters (e.g. _)
+                            are wildcards. Runs until interrupted.
 
   Advanced modes:
     --contract              Instead of account address, score the contract
@@ -134,6 +137,7 @@ usage: ./profanity2 [OPTIONS]
     ./profanity2 --leading f -z HEX_PUBLIC_KEY_128_CHARS_LONG
     ./profanity2 --matching dead -z HEX_PUBLIC_KEY_128_CHARS_LONG
     ./profanity2 --matching badXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXbad -z HEX_PUBLIC_KEY_128_CHARS_LONG
+    ./profanity2 --exact 1337________________________________c0de -z HEX_PUBLIC_KEY_128_CHARS_LONG
     ./profanity2 --leading-range -m 0 -M 1 -z HEX_PUBLIC_KEY_128_CHARS_LONG
     ./profanity2 --leading-range -m 10 -M 12 -z HEX_PUBLIC_KEY_128_CHARS_LONG
     ./profanity2 --range -m 0 -M 1 -z HEX_PUBLIC_KEY_128_CHARS_LONG
@@ -226,6 +230,30 @@ matches anything. The score is the number of matched fixed positions.
 Note: only results improving the best score so far are printed, so after a result matching
 all fixed positions is found nothing better can appear — stop the program with `Ctrl-C`.
 Keep in mind that every additional fixed character multiplies the expected search time by 16.
+
+### All exact matches (`-e`, `--exact`)
+
+`--exact` takes the same mask format as `--matching` (up to 40 characters, non-hex characters
+are wildcards) but skips the scoring system entirely: it prints **every** address that matches
+all fixed positions of the mask and keeps running until stopped with `Ctrl-C`. Use it when you
+want to collect several candidate addresses in one run instead of restarting `--matching` for
+each one:
+
+```bash
+# Every address 0x1337...c0de found, not just the first one
+./profanity2.x64 --exact 1337________________________________c0de -z $PUBLIC_KEY
+
+# Every address with at least five leading zeros
+./profanity2.x64 --exact 00000___________________________________ -z $PUBLIC_KEY
+```
+
+The first matches take longer to appear than with `--matching` (partial matches are not
+reported), and a very short mask can produce more matches per GPU round than the result
+buffer holds — the program prints a warning with the number of dropped matches if that
+happens.
+
+Note: if you have run an older version of profanity2 before, delete the `cache-opencl.*`
+files (or pass `--no-cache`) once so the OpenCL program is rebuilt with the new kernel.
 
 ### Character classes anywhere (`--zeros`, `--letters`, `--numbers`)
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ usage: ./profanity2 [OPTIONS]
     --leading <single hex>  Score on hashes leading with given hex character.
     --matching <hex string> Score on hashes matching given hex string.
     -e, --exact <hex mask>  Print every hash matching the given mask exactly,
-                            not just the best one. Non-hex characters (e.g. _)
+                            not just the best one. Non-hex characters (e.g. X)
                             are wildcards. Runs until interrupted.
 
   Advanced modes:
@@ -137,7 +137,7 @@ usage: ./profanity2 [OPTIONS]
     ./profanity2 --leading f -z HEX_PUBLIC_KEY_128_CHARS_LONG
     ./profanity2 --matching dead -z HEX_PUBLIC_KEY_128_CHARS_LONG
     ./profanity2 --matching badXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXbad -z HEX_PUBLIC_KEY_128_CHARS_LONG
-    ./profanity2 --exact 1337________________________________c0de -z HEX_PUBLIC_KEY_128_CHARS_LONG
+    ./profanity2 --exact 1337XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXc0de -z HEX_PUBLIC_KEY_128_CHARS_LONG
     ./profanity2 --leading-range -m 0 -M 1 -z HEX_PUBLIC_KEY_128_CHARS_LONG
     ./profanity2 --leading-range -m 10 -M 12 -z HEX_PUBLIC_KEY_128_CHARS_LONG
     ./profanity2 --range -m 0 -M 1 -z HEX_PUBLIC_KEY_128_CHARS_LONG
@@ -241,10 +241,10 @@ each one:
 
 ```bash
 # Every address 0x1337...c0de found, not just the first one
-./profanity2.x64 --exact 1337________________________________c0de -z $PUBLIC_KEY
+./profanity2.x64 --exact 1337XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXc0de -z $PUBLIC_KEY
 
 # Every address with at least five leading zeros
-./profanity2.x64 --exact 00000___________________________________ -z $PUBLIC_KEY
+./profanity2.x64 --exact 00000XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX -z $PUBLIC_KEY
 ```
 
 The first matches take longer to appear than with `--matching` (partial matches are not

--- a/help.hpp
+++ b/help.hpp
@@ -22,6 +22,9 @@ usage: ./profanity2 [OPTIONS]
   Modes with arguments:
     --leading <single hex>  Score on hashes leading with given hex character.
     --matching <hex string> Score on hashes matching given hex string.
+    -e, --exact <hex mask>  Print every hash matching the given mask exactly,
+                            not just the best one. Non-hex characters (e.g. _)
+                            are wildcards. Runs until interrupted.
 
   Advanced modes:
     --contract              Instead of account address, score the contract
@@ -51,6 +54,7 @@ usage: ./profanity2 [OPTIONS]
     ./profanity2 --leading f -z HEX_PUBLIC_KEY_128_CHARS_LONG
     ./profanity2 --matching dead -z HEX_PUBLIC_KEY_128_CHARS_LONG
     ./profanity2 --matching badXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXbad -z HEX_PUBLIC_KEY_128_CHARS_LONG
+    ./profanity2 --exact 1337________________________________c0de -z HEX_PUBLIC_KEY_128_CHARS_LONG
     ./profanity2 --leading-range -m 0 -M 1 -z HEX_PUBLIC_KEY_128_CHARS_LONG
     ./profanity2 --leading-range -m 10 -M 12 -z HEX_PUBLIC_KEY_128_CHARS_LONG
     ./profanity2 --range -m 0 -M 1 -z HEX_PUBLIC_KEY_128_CHARS_LONG

--- a/help.hpp
+++ b/help.hpp
@@ -23,7 +23,7 @@ usage: ./profanity2 [OPTIONS]
     --leading <single hex>  Score on hashes leading with given hex character.
     --matching <hex string> Score on hashes matching given hex string.
     -e, --exact <hex mask>  Print every hash matching the given mask exactly,
-                            not just the best one. Non-hex characters (e.g. _)
+                            not just the best one. Non-hex characters (e.g. X)
                             are wildcards. Runs until interrupted.
 
   Advanced modes:
@@ -54,7 +54,7 @@ usage: ./profanity2 [OPTIONS]
     ./profanity2 --leading f -z HEX_PUBLIC_KEY_128_CHARS_LONG
     ./profanity2 --matching dead -z HEX_PUBLIC_KEY_128_CHARS_LONG
     ./profanity2 --matching badXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXbad -z HEX_PUBLIC_KEY_128_CHARS_LONG
-    ./profanity2 --exact 1337________________________________c0de -z HEX_PUBLIC_KEY_128_CHARS_LONG
+    ./profanity2 --exact 1337XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXc0de -z HEX_PUBLIC_KEY_128_CHARS_LONG
     ./profanity2 --leading-range -m 0 -M 1 -z HEX_PUBLIC_KEY_128_CHARS_LONG
     ./profanity2 --leading-range -m 10 -M 12 -z HEX_PUBLIC_KEY_128_CHARS_LONG
     ./profanity2 --range -m 0 -M 1 -z HEX_PUBLIC_KEY_128_CHARS_LONG

--- a/profanity.cl
+++ b/profanity.cl
@@ -745,6 +745,37 @@ __kernel void profanity_score_benchmark(__global mp_number * const pInverse, __g
 	profanity_result_update(id, hash, pResult, score, scoreMax);
 }
 
+// Reports every hash that matches the given mask (data1) and pattern (data2)
+// exactly, unlike the scoring kernels which report at most one hash per score.
+//
+// pResult[0].found counts the matches found by this launch; matches are
+// appended at pResult[1..PROFANITY_MAX_SCORE] in arrival order. The host reads
+// the buffer and resets the counter to zero before every launch, so the bounds
+// check below also guarantees that no two work items ever write the same slot.
+// Matches beyond the buffer capacity are counted but not stored; the host
+// reports how many were dropped.
+__kernel void profanity_exact_match(__global mp_number * const pInverse, __global result * const pResult, __constant const uchar * const data1, __constant const uchar * const data2, const uchar scoreMax) {
+	const size_t id = get_global_id(0);
+	__global const uchar * const hash = (__global const uchar *)&pInverse[id].d[0];
+
+	for (int i = 0; i < 20; ++i) {
+		// Wildcard positions have zero mask bits in data1 and zero bits in
+		// data2, so they compare equal for any hash byte.
+		if ((hash[i] & data1[i]) != data2[i]) {
+			return;
+		}
+	}
+
+	const uint matchIndex = atomic_inc(&pResult[0].found);
+	if (matchIndex < PROFANITY_MAX_SCORE) {
+		pResult[matchIndex + 1].foundId = id;
+
+		for (int i = 0; i < 20; ++i) {
+			pResult[matchIndex + 1].foundHash[i] = hash[i];
+		}
+	}
+}
+
 __kernel void profanity_score_matching(__global mp_number * const pInverse, __global result * const pResult, __constant const uchar * const data1, __constant const uchar * const data2, const uchar scoreMax) {
 	const size_t id = get_global_id(0);
 	__global const uchar * const hash = (__global const uchar *)&pInverse[id].d[0];

--- a/profanity.cpp
+++ b/profanity.cpp
@@ -181,6 +181,7 @@ int main(int argc, char * * argv) {
 		bool bModeNumbers = false;
 		std::string strModeLeading;
 		std::string strModeMatching;
+		std::string strModeExact;
 		std::string strPublicKey;
 		bool bModeLeadingRange = false;
 		bool bModeRange = false;
@@ -218,6 +219,7 @@ int main(int argc, char * * argv) {
 		argp.addSwitch('c', "contract", bMineContract);
 		argp.addSwitch('z', "publicKey", strPublicKey);
 		argp.addSwitch('b', "zero-bytes", bModeZeroBytes);
+		argp.addSwitch('e', "exact", strModeExact);
 
 		if (!argp.parse()) {
 			std::cout << "error: bad arguments, try again :<" << std::endl;
@@ -242,6 +244,8 @@ int main(int argc, char * * argv) {
 			mode = Mode::leading(strModeLeading.front());
 		} else if (!strModeMatching.empty()) {
 			mode = Mode::matching(strModeMatching);
+		} else if (!strModeExact.empty()) {
+			mode = Mode::exact(strModeExact);
 		} else if (bModeLeadingRange) {
 			mode = Mode::leadingRange(rangeMin, rangeMax);
 		} else if (bModeRange) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a new `-e` / `--exact <hex mask>` mode that prints **every** address matching the given mask exactly and keeps running until interrupted, unlike `--matching` which prints at most one result per score increase.

```
./profanity2 --exact 1337XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXc0de -z HEX_PUBLIC_KEY_128_CHARS_LONG
./profanity2 --exact 00000XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX -z HEX_PUBLIC_KEY_128_CHARS_LONG
```

The mask uses the same format as `--matching`: up to 40 characters, any non-hex character (conventionally `X`) is a wildcard.

This is a clean reimplementation of the idea from #42 and addresses the use case from #32 — e.g. the second example above prints every address with at least five leading zeros.

## Implementation

A new kernel `profanity_exact_match` appends each full match to the existing result buffer using an atomic counter stored in `pResult[0].found`; matches land in `pResult[1..PROFANITY_MAX_SCORE]`. The host reads the buffer after every round (it already did this for all modes), prints the new results, and resets the device-side counter before the next round's kernel runs (the in-order command queue guarantees the read happens first).

Compared to the circular-buffer approach in #42, this per-round batch scheme fixes the issues found in that PR's review:

- **No GPU/host cursor mismatch.** #42's host cursor iterated slots 0..39 while the GPU wrote slots 1..40, so every 40th match was silently lost and a garbage private-key/address pair (from the cursor element) was printed once per buffer wrap-around. Here there are no cursors at all — the counter is reset every round and the buffer contents are always exactly the current round's matches.
- **No write race between work items.** The kernel only writes a slot when `matchIndex < PROFANITY_MAX_SCORE`, and the counter starts at zero each round, so two work items can never claim the same slot.
- **Overflow is reported, not silent.** If a round produces more matches than the buffer holds (possible with very short masks), the extra matches are counted and a warning with the dropped count is printed.
- **Windows build keeps working.** Uses `cl_uint` instead of the non-standard `uint` that #42 used (verified with a MinGW cross-compile).

Also fixes a pre-existing bug inherited by any mask mode: `Mode::matching` wrote past the 20-byte `data1`/`data2` arrays when given a mask longer than 40 characters. It now exits with a clear error instead.

## Notes

- In exact mode the `Score:` column is omitted from the output — every printed result is a full match.
- The result buffer drops `CL_MEM_HOST_READ_ONLY` in exact mode only, since the host has to write the counter reset (PoCL enforces this flag strictly and returned `CL_INVALID_OPERATION`).
- Users upgrading from an older build should delete `cache-opencl.*` (or pass `--no-cache`) once so the OpenCL program is rebuilt with the new kernel; this is noted in the README.

## Testing

All functional testing was done on a CPU OpenCL driver (PoCL), with a test-only local patch allowing `CL_DEVICE_TYPE_ALL` device selection; results were verified with an independent Python implementation (ecdsa + keccak) that recomputes the address from `seed_private + printed_private mod n`:

- `--exact be..ef` (4 fixed chars): 4614 results printed in 90 s, **all 4614 private keys derive addresses matching the printed address and the mask**, no duplicates.
- `--exact e...` (1 fixed char, deliberate overflow): buffer overflows every round, warning with dropped count printed each round; a 500-result sample verified key-correct.
- Mask longer than 40 chars: rejected with `hex mask must be at most 40 characters, got 41` instead of the previous out-of-bounds write.
- Regression: `--matching beef` and `--leading e` still print incrementally scored results; all printed keys verified correct.
- Linux: clean `make` with only pre-existing warnings. Windows portability: all translation units cross-compile with `x86_64-w64-mingw32-g++` without errors.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7be0b03b-630c-4db8-8a54-07f3590691f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7be0b03b-630c-4db8-8a54-07f3590691f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

