### PR TITLE
Fix command queue creation in PROFANITY_DEBUG builds

### DIFF
--- a/Dispatcher.cpp
+++ b/Dispatcher.cpp
@@ -141,7 +141,8 @@ cl_command_queue Dispatcher::Device::createQueue(cl_context & clContext, cl_devi
 #endif
 
 #ifdef CL_VERSION_2_0
-	const cl_command_queue ret = clCreateCommandQueueWithProperties(clContext, clDeviceId, &p, NULL);
+	const cl_queue_properties props[] = { CL_QUEUE_PROPERTIES, p, 0 };
+	const cl_command_queue ret = clCreateCommandQueueWithProperties(clContext, clDeviceId, props, NULL);
 #else
 	const cl_command_queue ret = clCreateCommandQueue(clContext, clDeviceId, p, NULL);
 #endif


### PR DESCRIPTION
## Symptom

Any build with `-DPROFANITY_DEBUG` dies immediately at startup:

```
failed to create command queue
```

The stock release build is unaffected and runs normally.

## Root cause

`Dispatcher::Device::createQueue` passes `&p` to `clCreateCommandQueueWithProperties`:

```c
#ifdef PROFANITY_DEBUG
	cl_command_queue_properties p = CL_QUEUE_PROFILING_ENABLE;
#else
	cl_command_queue_properties p = NULL;
#endif

#ifdef CL_VERSION_2_0
	const cl_command_queue ret = clCreateCommandQueueWithProperties(clContext, clDeviceId, &p, NULL);
```

`clCreateCommandQueueWithProperties` does not take a bitfield. Its third argument is a
zero-terminated `cl_queue_properties[]` list of `{property name, value, ...}` pairs.
`&p` is the address of a bare scalar, not such a list.

With `-DPROFANITY_DEBUG`, `p == CL_QUEUE_PROFILING_ENABLE` (`0x2`), so the runtime reads
the memory at `&p` as property name `0x2` followed by no value and no terminator. The
list is malformed, the call returns `NULL`, and the next line throws
`std::runtime_error("failed to create command queue")`.

## Why the release build is unaffected

In the release path `p == 0`, so `&p` points at a single zero word, which reads as a
valid *empty* property list. The call succeeds by accident. That is why this has gone
unnoticed: only the debug path puts a non-zero value in `p`, and every debug build has
been broken since OpenCL 2.0 headers became the norm.

The OpenCL 1.2 fallback (`clCreateCommandQueue`) is correct as written and is untouched,
since that function really does take a `cl_command_queue_properties` bitfield.

## Fix

```diff
 #ifdef CL_VERSION_2_0
-	const cl_command_queue ret = clCreateCommandQueueWithProperties(clContext, clDeviceId, &p, NULL);
+	const cl_queue_properties props[] = { CL_QUEUE_PROPERTIES, p, 0 };
+	const cl_command_queue ret = clCreateCommandQueueWithProperties(clContext, clDeviceId, props, NULL);
 #else
```

Two lines, no other changes.

## Verification

Linux / NVIDIA RTX 5090, Fedora 44, gcc 16.1.1, driver 595.71.05, OpenCL 3.0 (CUDA 13.2):

- Stock release build (unpatched master): compiles and runs clean at 2.089 GH/s.
- Stock `-DPROFANITY_DEBUG` build (unpatched master): aborts at startup with
  `failed to create command queue`.
- `-DPROFANITY_DEBUG` build with this patch: starts normally and emits the per-kernel
  profiling output the debug path is meant to produce.
- Release build with this patch: unchanged, no regression.

macOS (Apple `OpenCL.framework`): release build compiles clean with this patch. Note
that Apple's headers do not define `CL_VERSION_2_0`, so macOS takes the 1.2 fallback and
never reaches the changed line either way. The changed function was additionally
type-checked against the Khronos OpenCL 3.0 headers with and without
`-DPROFANITY_DEBUG`; both compile without warnings beyond the pre-existing
`NULL`-to-integer conversion on the line above.
