### PR TITLE
Report the OpenCL error code when command queue creation fails

### DIFF
--- a/Dispatcher.cpp
+++ b/Dispatcher.cpp
@@ -140,12 +140,14 @@ cl_command_queue Dispatcher::Device::createQueue(cl_context & clContext, cl_devi
 	cl_command_queue_properties p = NULL;
 #endif
 
+	cl_int errorCode = CL_SUCCESS;
 #ifdef CL_VERSION_2_0
 	const cl_queue_properties props[] = { CL_QUEUE_PROPERTIES, p, 0 };
-	const cl_command_queue ret = clCreateCommandQueueWithProperties(clContext, clDeviceId, props, NULL);
+	const cl_command_queue ret = clCreateCommandQueueWithProperties(clContext, clDeviceId, props, &errorCode);
 #else
-	const cl_command_queue ret = clCreateCommandQueue(clContext, clDeviceId, p, NULL);
+	const cl_command_queue ret = clCreateCommandQueue(clContext, clDeviceId, p, &errorCode);
 #endif
+	OpenCLException::throwIfError("failed to create command queue", errorCode);
 	return ret == NULL ? throw std::runtime_error("failed to create command queue") : ret;
 }
 


### PR DESCRIPTION
createQueue passed NULL for errcode_ret and threw a bare std::runtime_error, so a failure gave no indication of what the runtime had actually rejected. That is why the malformed property list fixed in #58 went unnoticed for years: the driver was returning CL_INVALID_VALUE and the message discarded it.

Capture errcode_ret and route it through the existing OpenCLException, which formats the code into the message. The same failure now reports "failed to create command queue (res = -30)".

The NULL guard is kept so a driver that returns NULL alongside CL_SUCCESS is still caught.
