### PR TITLE
Use 0 rather than NULL for the empty command queue property set

### DIFF
--- a/Dispatcher.cpp
+++ b/Dispatcher.cpp
@@ -137,7 +137,7 @@ cl_command_queue Dispatcher::Device::createQueue(cl_context & clContext, cl_devi
 #ifdef PROFANITY_DEBUG
 	cl_command_queue_properties p = CL_QUEUE_PROFILING_ENABLE;
 #else
-	cl_command_queue_properties p = NULL;
+	cl_command_queue_properties p = 0;
 #endif
 
 #ifdef CL_VERSION_2_0


### PR DESCRIPTION
Drive-by cleanup noticed while reviewing #58, on the line directly above the one that PR changed.

## Problem

`cl_command_queue_properties` is a `cl_bitfield`, which is a `cl_ulong`. It is not a pointer type, so initialising it from `NULL` depends on the null pointer constant converting to an integer. gcc flags this under `-Wall`, which `Makefile` enables for every build:

```
Dispatcher.cpp:140:41: warning: converting to non-pointer type
'cl_command_queue_properties' {aka 'long unsigned int'} from NULL [-Wconversion-null]
```

Beyond the noise, `NULL` here reads as "no properties pointer", which is misleading: `p` is a bitfield of queue property flags, and the intended value is the empty flag set.

## Change

```diff
 #ifdef PROFANITY_DEBUG
 	cl_command_queue_properties p = CL_QUEUE_PROFILING_ENABLE;
 #else
-	cl_command_queue_properties p = NULL;
+	cl_command_queue_properties p = 0;
 #endif
```

This matches the `#ifdef` branch above it, which already assigns a bitfield constant.

## Verification

Linux, OpenCL 3.0 headers, gcc 13, built with the project's own flags (`-std=c++11 -Wall -O2 -mcmodel=large`).

- This was the only `-Wconversion-null` in the project. Both the release and the `-DPROFANITY_DEBUG` build now report zero, leaving only the unrelated pre-existing `-Waligned-new=` note on `new Dispatcher::Device`.
- The emitted object file is byte-identical before and after (`md5 3e19513d758d567d6c1e15acdbfffbb1` either way), so this is a provable no-op at the machine code level.