### PR TITLE
Remove the unreachable macOS command queue alias

### DIFF
--- a/Dispatcher.hpp
+++ b/Dispatcher.hpp
@@ -9,7 +9,6 @@
 
 #if defined(__APPLE__) || defined(__MACOSX)
 #include <OpenCL/cl.h>
-#define clCreateCommandQueueWithProperties clCreateCommandQueue
 #else
 #include <CL/cl.h>
 #endif


### PR DESCRIPTION
Noticed while reviewing #58. Follow-up cleanup, no functional change.

## What it is

`Dispatcher.hpp` aliases an OpenCL API function on Apple targets:

```c
#if defined(__APPLE__) || defined(__MACOSX)
#include <OpenCL/cl.h>
#define clCreateCommandQueueWithProperties clCreateCommandQueue   // <- removed
#else
#include <CL/cl.h>
#endif
```

The alias can never fire, and if it ever could it would not work.

## Why it can never fire

The macro exists only when `__APPLE__` is defined, which the compiler sets from the target OS. Its only possible call site sits inside `#ifdef CL_VERSION_2_0`, which comes from the OpenCL headers. Those two conditions never hold at once.

Checked against the genuine `OpenCL.framework` header from the MacOSX 10.15 SDK:

- defines `CL_VERSION_1_0`, `CL_VERSION_1_1`, `CL_VERSION_1_2`, and **not** `CL_VERSION_2_0`
- does **not declare** `clCreateCommandQueueWithProperties`
- does **not define** `cl_queue_properties`
- declares `clCreateCommandQueue`, marked `CL_DEPRECATED(10.6, 10.14)`

Apple froze OpenCL at 1.2 and deprecated it in 10.14; this is true on Apple Silicon too, where the GPU still reports `OpenCL 1.2`. So macOS always takes the OpenCL 1.2 branch, which calls `clCreateCommandQueue` directly and needs no alias.

## Why it would not work anyway

The two functions differ in their third parameter:

```c
clCreateCommandQueueWithProperties(ctx, dev, const cl_queue_properties * /* zero-terminated list */, cl_int *)
clCreateCommandQueue              (ctx, dev, cl_command_queue_properties /* bitfield */,             cl_int *)
```

Renaming the symbol does not convert the argument. If the alias were reachable it would pass an array pointer where an integer is expected, which is a compile error, not working code. So the only two possible outcomes are "does nothing" and "build breaks". The protection it was presumably written for is already provided by the `#ifdef CL_VERSION_2_0` guard below it.

## Supporting evidence from the tree

Four other files carry the identical `__APPLE__` include block and none of them has the define: `types.hpp`, `Mode.hpp`, `profanity.cpp`, `tests/testutil.hpp`. The last one already calls `clCreateCommandQueue` directly on macOS without needing an alias. `Dispatcher.hpp` is the outlier.

Worth noting the macro also had no `#undef`, so it leaked the rename into every translation unit that includes `Dispatcher.hpp`.

## Verification

A macOS-faithful include tree was built from the real Apple `cl.h` and `cl_platform.h` (only `AvailabilityMacros.h` and `os/availability.h` are stubs, since availability attributes are linker metadata and cannot affect which declarations exist or which preprocessor branch is taken).

Preprocessed output (`g++ -E`) is **byte-identical before and after** in every affected configuration:

| Translation unit | Apple header path | Khronos header path |
|---|---|---|
| `Dispatcher.cpp`, release | identical | identical |
| `Dispatcher.cpp`, `-DPROFANITY_DEBUG` | identical | identical |
| `profanity.cpp` | identical | identical |
| `Mode.cpp` | identical | identical |

Since the preprocessor is the only thing a `#define` can affect, that is a proof rather than a sample.

Also confirmed:

- `Dispatcher.cpp` syntax-checks clean against the real Apple headers after removal, with zero errors.
- Full Linux build succeeds in both release and `-DPROFANITY_DEBUG`.
- `Dispatcher.o` is byte-identical before and after (`md5 3e19513d758d567d6c1e15acdbfffbb1`).