### PR TITLE
Remove the unused loop counter in printSpeed

### DIFF
--- a/Dispatcher.cpp
+++ b/Dispatcher.cpp
@@ -544,12 +544,10 @@ void Dispatcher::printSpeed() {
 	if( m_countPrint > m_vDevices.size() ) {
 		std::string strGPUs;
 		double speedTotal = 0;
-		unsigned int i = 0;
 		for (auto & e : m_vDevices) {
 			const auto curSpeed = e->m_speed.getSpeed();
 			speedTotal += curSpeed;
 			strGPUs += " GPU" + toString(e->m_index) + ": " + formatSpeed(curSpeed);
-			++i;
 		}
 
 		const std::string strVT100ClearLine = "\33[2K\r";


### PR DESCRIPTION
## Summary

`printSpeed` keeps a loop counter that nothing reads, and clang warns about it on every build:

```
Dispatcher.cpp:547:16: warning: variable 'i' set but not used [-Wunused-but-set-variable]
```

The counter is a leftover. It was introduced in 89ed68c (2018-03-11) and was read at the time, supplying the GPU label via `toString(i)`. The very next day e46719d switched that to `toString(e->m_index)` so the printed index would match the device index rather than the vector position, but left the counter and its increment behind. Nothing has read it since.

gcc does not report this even with `-Wall -Wextra`, because it treats `++i` as a read of `i`. clang follows the def-use chain and sees the value never escapes, which is why the warning only shows up on macOS builds, where `g++` is clang.

## Test plan

- [x] `Dispatcher.o` is byte-identical before and after, in both the release and the `PROFANITY_DEBUG` configuration, so the compiler was already discarding the counter
- [ ] CI builds the image

Made with [Cursor](https://cursor.com)